### PR TITLE
Add issue analyzer skill and documentation updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Repository Rules
+
+- When adding or updating a Forge summonable/skill/agent across assistant systems, follow `./docs/adding-skill-agent-template.md` as the required implementation checklist.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Forge
 
-Forge installs a GitHub Copilot discussion-analysis runtime under `~/.copilot`, Claude assets under `~/.claude`, Codex assets under `~/.codex`, and Gemini assets under `~/.gemini`.
+Forge installs GitHub discussion-analysis and issue-analysis runtimes under `~/.copilot`, `~/.claude`, `~/.codex`, and `~/.gemini`.
 
 ## Install
 
@@ -30,41 +30,54 @@ npm_config_prefer_online=true npx forge-ai-assist@latest
 In Copilot:
 
 1. Run `/agent`
-2. Select `forge-discussion-analyzer`
-3. Ask a question about GitHub Discussions
+2. Select `forge-discussion-analyzer` or `forge-issue-analyzer`
+3. Ask a question about GitHub Discussions or GitHub Issues
 
-For `gh copilot`, Forge also installs a matching skill at `~/.copilot/skills/forge-discussion-analyzer/SKILL.md` so agent delegation resolves back to the same Forge command instead of failing with `Skill not found`.
+For `gh copilot`, Forge installs matching skills at:
+- `~/.copilot/skills/forge-discussion-analyzer/SKILL.md`
+- `~/.copilot/skills/forge-issue-analyzer/SKILL.md`
+
+This keeps delegation pointed at the same Forge command instead of failing with `Skill not found`.
 
 In Claude Code:
 
-1. Use the installed `forge:discussion-analyzer` command
-2. The command delegates to the installed `forge-discussion-analyzer` agent and the runtime bundle under `~/.claude/forge`
-3. Ask a question about GitHub Discussions
+1. Use the installed `forge:discussion-analyzer` or `forge:issue-analyzer` command
+2. The command delegates to the matching installed agent and the runtime bundle under `~/.claude/forge`
+3. Ask a question about GitHub Discussions or GitHub Issues
 
 In Codex:
 
-1. Use the installed `$forge-discussion-analyzer` skill from `~/.codex/skills/forge-discussion-analyzer/SKILL.md`
+1. Use `$forge-discussion-analyzer` or `$forge-issue-analyzer` from `~/.codex/skills/`
 2. Codex also gets a matching agent and agent TOML under `~/.codex/agents/`
-3. Ask a question about GitHub Discussions
+3. Ask a question about GitHub Discussions or GitHub Issues
 
 In Gemini:
 
-1. Use the installed `forge:discussion-analyzer` command from `~/.gemini/commands/forge/discussion-analyzer.toml`
+1. Use `forge:discussion-analyzer` or `forge:issue-analyzer` from `~/.gemini/commands/forge/`
 2. Gemini also gets a matching agent under `~/.gemini/agents/`
-3. Ask a question about GitHub Discussions
+3. Ask a question about GitHub Discussions or GitHub Issues
 
 ## Custom Instructions
 
 Forge installs:
 - `~/.copilot/agents/forge-discussion-analyzer.agent.md`
 - `~/.copilot/skills/forge-discussion-analyzer/SKILL.md`
+- `~/.copilot/agents/forge-issue-analyzer.agent.md`
+- `~/.copilot/skills/forge-issue-analyzer/SKILL.md`
 - `~/.claude/commands/forge/discussion-analyzer.md`
 - `~/.claude/agents/forge-discussion-analyzer.md`
+- `~/.claude/commands/forge/issue-analyzer.md`
+- `~/.claude/agents/forge-issue-analyzer.md`
 - `~/.codex/skills/forge-discussion-analyzer/SKILL.md`
 - `~/.codex/agents/forge-discussion-analyzer.md`
 - `~/.codex/agents/forge-discussion-analyzer.toml`
+- `~/.codex/skills/forge-issue-analyzer/SKILL.md`
+- `~/.codex/agents/forge-issue-analyzer.md`
+- `~/.codex/agents/forge-issue-analyzer.toml`
 - `~/.gemini/commands/forge/discussion-analyzer.toml`
 - `~/.gemini/agents/forge-discussion-analyzer.md`
+- `~/.gemini/commands/forge/issue-analyzer.toml`
+- `~/.gemini/agents/forge-issue-analyzer.md`
 
 The markdown assets include a preserved user-customizations block.
 
@@ -77,7 +90,8 @@ The markdown assets include a preserved user-customizations block.
 
 ## Notes
 
-- This discussion-analyzer works with GitHub Discussions only, not GitHub Issues.
+- `forge-discussion-analyzer` works with GitHub Discussions only.
+- `forge-issue-analyzer` works with GitHub Issues only.
 - Analysis traces are written to the repository `.forge` directory.
 - Forge installs into `~/.copilot`, `~/.claude`, `~/.codex`, and `~/.gemini`. It does not install any files under `~/.config/gh`.
 - If Forge hits a network or GitHub API timeout, the installed Copilot agent is expected to report the Forge failure and stop rather than falling back to raw `gh api` calls.

--- a/docs/adding-skill-agent-template.md
+++ b/docs/adding-skill-agent-template.md
@@ -1,0 +1,177 @@
+# Template: Add a New Skill/Agent Across Systems
+
+Use this template when adding a new Forge summonable capability that should install into all assistant runtimes (Copilot, Claude, Codex, Gemini).
+
+## 1) Define Inputs
+
+Fill these before editing code:
+
+- `ENTRY_ID`: stable kebab-case id, ex: `forge-release-risk-analyzer`
+- `DISPLAY_NAME`: ex: `Forge Release Risk Analyzer`
+- `PURPOSE`: one-sentence scope
+- `QUESTION_HINT`: what user question this summonable expects
+- `RUNTIME_HANDLER`: backend function name, ex: `runReleaseRiskAnalyzer`
+- `RUNTIME_DOMAIN`: service folder, ex: `src/services/release-risk/`
+
+Rules:
+
+- Keep `ENTRY_ID` stable after release.
+- Prefix with `forge-` to preserve namespace behavior (`forge:...`) for Claude/Gemini commands.
+
+## 2) Add The Summonable Entry
+
+File: `src/services/assistants/summonables.ts`
+
+1. Add a new `SummonableEntry` constant (copy the existing `forgeDiscussionAnalyzerEntry` shape).
+2. Add the new entry to `forgeSummonableEntries`.
+
+Template snippet:
+
+```ts
+export const ENTRY_CONST: SummonableEntry = {
+  id: 'ENTRY_ID',
+  displayName: 'DISPLAY_NAME',
+  purpose: 'PURPOSE',
+  instructions: [
+    'Instruction 1',
+    'Instruction 2',
+  ].map((line) => `- ${line}`).join('\n'),
+  capabilities: [
+    {
+      name: 'Capability',
+      description: 'What it does',
+      benefits: ['Benefit A', 'Benefit B'],
+    },
+  ],
+  commands: [
+    {
+      name: '/agent ENTRY_ID',
+      description: 'Select this agent and ask a question.',
+      usage: `${COPILOT_RUNTIME_ENTRY} --run ENTRY_ID --question "<your question>"`,
+      examples: [
+        '/agent -> select ENTRY_ID -> "QUESTION_HINT"',
+      ],
+    },
+  ],
+  principles: [
+    'Principle 1',
+  ],
+};
+```
+
+## 3) Add Runtime Backend Wiring
+
+Files:
+
+- `src/program.ts`
+- `src/services/<domain>/...` (new backend implementation)
+
+Forge currently supports multiple summonables (`forge-discussion-analyzer`, `forge-issue-analyzer`), so new summonables require dispatch changes.
+
+Minimum update:
+
+1. Implement backend runner (`RUNTIME_HANDLER`) for the new summonable.
+2. Extend `--run`/`--run-summonable` dispatch to accept the new `ENTRY_ID`.
+3. Keep unknown analyzer error explicit and list valid ids.
+
+## 4) Render Assistant Assets For The New Entry
+
+Files:
+
+- `src/services/assistants/runtime-rendering.ts`
+- `src/services/assistants/render-entry.ts` (if shared markdown helpers need extension)
+
+Required behavior:
+
+- Generated command/agent/skill text must execute:
+  - `node "$HOME/.<assistant>/forge/bin/forge.mjs" --run ENTRY_ID --question "..."`
+- Preserve managed/user customization markers:
+  - `<!-- BEGIN FORGE MANAGED BLOCK -->`
+  - `<!-- END FORGE MANAGED BLOCK -->`
+  - `<!-- BEGIN USER CUSTOMIZATIONS -->`
+  - `<!-- END USER CUSTOMIZATIONS -->`
+
+If prompt copy is analyzer-specific, add a dedicated renderer for the new summonable or parameterize existing helpers by `entry.id`.
+
+## 5) Confirm Per-Assistant Surface Mapping
+
+No new adapter is needed for this task. Existing adapters install all entries from `forgeSummonableEntries`.
+
+Verify each adapter still produces correct assets for `ENTRY_ID`:
+
+- Copilot (`src/services/assistants/copilot.ts`)
+  - Primary: `~/.copilot/agents/ENTRY_ID.agent.md`
+  - Supplemental: `~/.copilot/skills/ENTRY_ID/SKILL.md`
+- Claude (`src/services/assistants/claude.ts`)
+  - Primary command: `~/.claude/commands/<namespace>/<local>.md`
+  - Supplemental: `~/.claude/agents/ENTRY_ID.md`
+  - Supplemental: `~/.claude/forge/workflows/<local>.md`
+- Codex (`src/services/assistants/codex.ts`)
+  - Primary skill: `~/.codex/skills/ENTRY_ID/SKILL.md`
+  - Supplemental: `~/.codex/agents/ENTRY_ID.md`
+  - Supplemental: `~/.codex/agents/ENTRY_ID.toml`
+  - Supplemental: `~/.codex/forge/workflows/<local>.md`
+- Gemini (`src/services/assistants/gemini.ts`)
+  - Primary command: `~/.gemini/commands/<namespace>/<local>.toml`
+  - Supplemental: `~/.gemini/agents/ENTRY_ID.md`
+  - Supplemental: `~/.gemini/forge/workflows/<local>.md`
+
+Notes:
+
+- `<namespace>/<local>` comes from first `-` split in `ENTRY_ID` via `getSummonableRoute`.
+- Claude/Gemini command names are namespaced (`forge:local-name`) via `getExposedSummonableName`.
+
+## 6) Update Installer UX Copy
+
+File: `src/commands/install-assistants.ts`
+
+If success text references only `forgeDiscussionAnalyzerEntry`, update it to include the new summonable (or make it generic for multi-entry installs).
+
+## 7) Add/Update Tests
+
+At minimum update:
+
+- `tests/unit/services/assistant-exposure.test.ts`
+- `tests/unit/services/claude-assistants.test.ts`
+- `tests/unit/services/codex-gemini-assistants.test.ts`
+- `tests/smoke/cli.test.ts`
+
+If runtime dispatch changes, add/adjust tests around `src/program.ts` behavior and backend execution.
+
+Test expectations to preserve:
+
+- Correct install paths per assistant
+- New content references `--run ENTRY_ID`
+- Reinstall preserves user customization blocks
+- Legacy migration behavior (if old paths are introduced)
+
+## 8) Update Docs
+
+At minimum update:
+
+- `README.md` (usage + installed file list)
+- `docs/releasing.md` (release validation checks)
+
+## 9) Verify End-To-End
+
+Run:
+
+```bash
+npm run build
+npm test
+```
+
+Optional manual spot checks:
+
+```bash
+node dist/cli.js --assistants codex
+node dist/cli.js --run ENTRY_ID --question "QUESTION_HINT"
+```
+
+## Done Criteria
+
+- New summonable appears in `forgeSummonableEntries`.
+- All four assistant systems install valid assets for the new id.
+- Runtime `--run ENTRY_ID` executes the correct backend.
+- Managed/user customization markers remain intact after reinstall.
+- Unit + smoke tests pass.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,6 +29,7 @@ node "$HOME/.copilot/forge/bin/forge.mjs" --help
 Expected result:
 
 - `~/.copilot/agents/forge-discussion-analyzer.agent.md` exists
+- `~/.copilot/agents/forge-issue-analyzer.agent.md` exists
 - `~/.copilot/forge/node_modules` exists
 - no manual `npm install` is needed inside `~/.copilot/forge`
 - users can add their own instructions inside the preserved user-customizations block of `forge-discussion-analyzer.agent.md` without losing them on upgrade

--- a/src/commands/install-assistants.ts
+++ b/src/commands/install-assistants.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import readline from 'node:readline/promises';
 import { assistantInstallService } from '../services/assistants/install.js';
 import { AssistantId, AssistantOperationResult } from '../contracts/assistants.js';
-import { forgeDiscussionAnalyzerEntry } from '../services/assistants/summonables.js';
+import { forgeDiscussionAnalyzerEntry, forgeIssueAnalyzerEntry } from '../services/assistants/summonables.js';
 import { getExposedSummonableName } from '../services/assistants/exposure.js';
 
 const DEFAULT_ASSISTANTS: AssistantId[] = ['copilot', 'claude', 'codex', 'gemini'];
@@ -63,7 +63,12 @@ export async function installAssistantsCommand(
     
     if (hasSuccess) {
       const successMessage = buildSuccessMessage(requestedAssistants);
-      console.log(interactive ? `\n${styling.green('Done!')} ${successMessage}` : successMessage);
+      if (interactive) {
+        console.log(`\n${styling.green('Done!')}`);
+        console.log(successMessage);
+      } else {
+        console.log(successMessage);
+      }
     } else {
       console.log('\nForge assistant assets were not installed or updated. Check the status messages above.');
     }
@@ -126,26 +131,33 @@ function printInstallTargets(
 }
 
 function buildSuccessMessage(assistantIds: AssistantId[]): string {
-  const notes: string[] = [];
+  const lines: string[] = ['Available Forge entrypoints:'];
+  const discussionSkill = getExposedSummonableName('codex', 'skill', forgeDiscussionAnalyzerEntry);
+  const issueSkill = getExposedSummonableName('codex', 'skill', forgeIssueAnalyzerEntry);
+  const discussionClaudeCommand = getExposedSummonableName('claude', 'command', forgeDiscussionAnalyzerEntry);
+  const issueClaudeCommand = getExposedSummonableName('claude', 'command', forgeIssueAnalyzerEntry);
+  const discussionGeminiCommand = getExposedSummonableName('gemini', 'command', forgeDiscussionAnalyzerEntry);
+  const issueGeminiCommand = getExposedSummonableName('gemini', 'command', forgeIssueAnalyzerEntry);
 
   if (assistantIds.includes('copilot')) {
-    notes.push('Copilot can use `/agent forge-discussion-analyzer`, and gh copilot can delegate to the matching `forge-discussion-analyzer` skill');
+    lines.push('- Copilot agents: `/agent forge-discussion-analyzer`, `/agent forge-issue-analyzer`');
+    lines.push('- Copilot skills (gh copilot): `forge-discussion-analyzer`, `forge-issue-analyzer`');
   }
 
   if (assistantIds.includes('claude')) {
-    notes.push(`Claude can use the installed ${getExposedSummonableName('claude', 'command', forgeDiscussionAnalyzerEntry)} command`);
+    lines.push(`- Claude commands: \`${discussionClaudeCommand}\`, \`${issueClaudeCommand}\``);
   }
 
   if (assistantIds.includes('codex')) {
-    notes.push(`Codex can use the installed $${getExposedSummonableName('codex', 'skill', forgeDiscussionAnalyzerEntry)} skill`);
+    lines.push(`- Codex skills: \`$${discussionSkill}\`, \`$${issueSkill}\``);
   }
 
   if (assistantIds.includes('gemini')) {
-    notes.push(`Gemini can use the installed ${getExposedSummonableName('gemini', 'command', forgeDiscussionAnalyzerEntry)} command`);
+    lines.push(`- Gemini commands: \`${discussionGeminiCommand}\`, \`${issueGeminiCommand}\``);
   }
 
-  return notes.length > 0
-    ? `${notes.join(', ')}.`
+  return lines.length > 1
+    ? lines.join('\n')
     : 'Forge assistant assets are ready.';
 }
 
@@ -172,7 +184,7 @@ export function renderInteractiveInstallerScreen(version: string, styling: Insta
     ...bannerLines,
     '',
     `  ${styling.bold(`Forge v${version}`)}`,
-    `  ${styling.dim('Live-fetch GitHub Discussions installer for GitHub Copilot, Claude Code, Gemini, and Codex.')}`,
+    `  ${styling.dim('Live-fetch GitHub Discussions and Issues installer for GitHub Copilot, Claude Code, Gemini, and Codex.')}`,
     '',
     `  ${styling.bold('Which runtime(s) would you like to install for?')}`,
     '',

--- a/src/contracts/issues.ts
+++ b/src/contracts/issues.ts
@@ -1,0 +1,108 @@
+import { GitHubRepositoryRef } from './discussions.js';
+
+export interface IssueFilters {
+  when?: 'today' | 'yesterday' | 'last-week';
+  after?: string;
+  before?: string;
+  state: 'open' | 'closed' | 'all';
+  label?: string;
+  dateField: 'createdAt' | 'updatedAt';
+  limit: number;
+}
+
+export interface IssueRecord {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt?: string | null;
+  state: 'open' | 'closed';
+  author?: string;
+  labels: string[];
+  bodyText: string;
+  commentsCount: number;
+}
+
+export interface IssueRun {
+  version: '1.0';
+  id: string;
+  timestamp: string;
+  repository: GitHubRepositoryRef;
+  filters: IssueFilters;
+  pageInfo: {
+    hasNextPage: boolean;
+    fetchedPages: number;
+    nextPage?: number;
+  };
+  issueCount: number;
+  issues: IssueRecord[];
+}
+
+export type IssueStatus = 'open' | 'closed' | 'blocked' | 'in-progress';
+
+export type IssueKind =
+  | 'bug'
+  | 'feature-request'
+  | 'documentation'
+  | 'maintenance'
+  | 'question'
+  | 'task';
+
+export interface PreparedIssueRecord {
+  number: number;
+  title: string;
+  url: string;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  state: 'open' | 'closed';
+  status: IssueStatus;
+  kind: IssueKind;
+  issue: string;
+  resolution: string;
+  keyContext: string[];
+  actionItems: string[];
+  teamMentions: string[];
+  searchableText: string;
+}
+
+export interface PreparedIssueDigest {
+  version: '1.0';
+  id: string;
+  sourceRunId: string;
+  timestamp: string;
+  repository: GitHubRepositoryRef;
+  filters: IssueFilters;
+  totals: {
+    issues: number;
+    states: Record<string, number>;
+    statuses: Record<string, number>;
+    kinds: Record<string, number>;
+    labels: Record<string, number>;
+  };
+  records: PreparedIssueRecord[];
+}
+
+export interface IssueSummaryArtifact {
+  version: '1.0';
+  id: string;
+  timestamp: string;
+  question: string;
+  repository: GitHubRepositoryRef;
+  sourceRunId: string;
+  source: 'live-fetch';
+  filters: {
+    when?: string;
+    after?: string;
+    before?: string;
+    state?: 'open' | 'closed' | 'all';
+    label?: string;
+    dateField?: 'createdAt' | 'updatedAt';
+  };
+  issueCount: number;
+  stateBreakdown: Record<string, number>;
+  labelBreakdown: Record<string, number>;
+  answer: string;
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -58,6 +58,13 @@ export class GitHubDiscussionsFetchError extends UserFacingError {
   }
 }
 
+export class GitHubIssuesFetchError extends UserFacingError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitHubIssuesFetchError';
+  }
+}
+
 export class DiscussionArtifactsRequiredError extends UserFacingError {
   constructor(
     message = 'No discussion artifacts found. Fetch discussions first with Forge before running forge-discussion-analyzer.'
@@ -71,5 +78,21 @@ export class DiscussionsOnlyAnalyzerError extends UserFacingError {
   constructor(message: string) {
     super(message);
     this.name = 'DiscussionsOnlyAnalyzerError';
+  }
+}
+
+export class IssueArtifactsRequiredError extends UserFacingError {
+  constructor(
+    message = 'No issue artifacts found. Fetch issues first with Forge before running forge-issue-analyzer.'
+  ) {
+    super(message);
+    this.name = 'IssueArtifactsRequiredError';
+  }
+}
+
+export class IssuesOnlyAnalyzerError extends UserFacingError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IssuesOnlyAnalyzerError';
   }
 }

--- a/src/program.ts
+++ b/src/program.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { installAssistantsCommand } from "./commands/install-assistants.js";
 import { runDiscussionAnalyzer } from "./services/discussions/analyze.js";
+import { runIssueAnalyzer } from "./services/issues/analyze.js";
 import { AssistantId } from "./contracts/assistants.js";
 
 type PackageManifest = {
@@ -25,11 +26,14 @@ type ProgramOptions = {
   after?: string;
   before?: string;
   category?: string;
+  issueState?: string;
+  label?: string;
   discussionLimit?: string;
 };
 
 const EXECUTABLE_NAME = "forge";
-const DEFAULT_ANALYZER_ID = "forge-discussion-analyzer";
+const ANALYZER_IDS = ["forge-discussion-analyzer", "forge-issue-analyzer"] as const;
+type AnalyzerId = (typeof ANALYZER_IDS)[number];
 
 async function readPackageManifest(): Promise<PackageManifest> {
   const manifestUrl = new URL("../package.json", import.meta.url);
@@ -45,7 +49,7 @@ export async function createProgram(): Promise<Command> {
 
   program
     .name(EXECUTABLE_NAME)
-    .description("Install Forge assistant assets for Copilot, Claude, Codex, and Gemini, and run Forge-managed GitHub discussion workflows.")
+    .description("Install Forge assistant assets for Copilot, Claude, Codex, and Gemini, and run Forge-managed GitHub discussion and issue workflows.")
     .version(manifest.version ?? "0.0.0", "-v, --version", "output the current version")
     .option("--cwd <path>", "The working directory to run the command in.", process.cwd())
     .option("--verbose", "Show detailed installer update output.")
@@ -53,12 +57,14 @@ export async function createProgram(): Promise<Command> {
     .option("--run <analyzer>", "Run a Forge-managed analyzer.")
     .option("--question <text>", "Question or request for Forge-managed assistant execution.")
     .option("--refresh-analysis", "Re-run the live discussion analysis before answering.")
-    .option("--force-refresh", "Compatibility flag. The discussion analyzer already fetches live on every run.")
-    .option("--github-token <token>", "Explicit GitHub token override for discussions fetches.")
-    .option("--when <window>", "Relative discussions window: today, yesterday, or last-week.")
-    .option("--after <date>", "Only include discussions created on or after this date by default.")
-    .option("--before <date>", "Only include discussions created on or before this date by default.")
+    .option("--force-refresh", "Compatibility flag. Forge analyzers already fetch live on every run.")
+    .option("--github-token <token>", "Explicit GitHub token override for analyzer fetches.")
+    .option("--when <window>", "Relative analyzer window: today, yesterday, or last-week.")
+    .option("--after <date>", "Only include analyzer records created on or after this date by default.")
+    .option("--before <date>", "Only include analyzer records created on or before this date by default.")
     .option("--category <name>", "Filter discussions by GitHub discussion category name or slug.")
+    .option("--issue-state <state>", "Issue state filter: open, closed, or all.")
+    .option("--label <name>", "Filter issues by GitHub issue label.")
     .option("--discussion-limit <number>", "Maximum number of discussions to persist (1-5000).", "500")
     .addOption(new Option("--run-summonable <id>", "Run a Forge-managed assistant backend directly.").hideHelp())
     .hook("preAction", (thisCommand) => {
@@ -73,11 +79,8 @@ export async function createProgram(): Promise<Command> {
     const requestedAnalyzer = options.run ?? options.runSummonable;
 
     if (requestedAnalyzer) {
-      if (requestedAnalyzer !== DEFAULT_ANALYZER_ID) {
-        throw new Error(`Unknown analyzer "${requestedAnalyzer}". The available analyzer is ${DEFAULT_ANALYZER_ID}.`);
-      }
-
-      const answer = await runDiscussionAnalyzer({
+      const parsedAnalyzer = parseAnalyzerId(requestedAnalyzer);
+      const sharedOptions = {
         cwd: options.cwd,
         question: options.question ?? '',
         forceRefresh: options.forceRefresh,
@@ -86,9 +89,18 @@ export async function createProgram(): Promise<Command> {
         when: options.when,
         after: options.after,
         before: options.before,
-        category: options.category,
         limit: Number.parseInt(options.discussionLimit ?? "500", 10),
-      });
+      };
+      const answer = parsedAnalyzer === "forge-discussion-analyzer"
+        ? await runDiscussionAnalyzer({
+            ...sharedOptions,
+            category: options.category,
+          })
+        : await runIssueAnalyzer({
+            ...sharedOptions,
+            state: options.issueState,
+            label: options.label,
+          });
       console.log(answer);
       return;
     }
@@ -101,6 +113,14 @@ export async function createProgram(): Promise<Command> {
   });
 
   return program;
+}
+
+function parseAnalyzerId(value: string): AnalyzerId {
+  if ((ANALYZER_IDS as readonly string[]).includes(value)) {
+    return value as AnalyzerId;
+  }
+
+  throw new Error(`Unknown analyzer "${value}". Available analyzers: ${ANALYZER_IDS.join(', ')}.`);
 }
 
 function parseAssistantSelection(value?: string): AssistantId[] | undefined {

--- a/src/services/assistants/forge-agent.ts
+++ b/src/services/assistants/forge-agent.ts
@@ -1,5 +1,6 @@
 export {
   forgeDiscussionAnalyzerEntry,
+  forgeIssueAnalyzerEntry,
   forgeSummonableEntries,
 } from './summonables.js';
 

--- a/src/services/assistants/runtime-rendering.ts
+++ b/src/services/assistants/runtime-rendering.ts
@@ -2,7 +2,49 @@ import { SummonableEntry } from '../../contracts/summonable-entry.js';
 import { FORGE_MANAGED_END, FORGE_MANAGED_START, FORGE_USER_END, FORGE_USER_START } from './copilot.js';
 import { getExposedSummonableName, getSummonableRoute } from './exposure.js';
 
-const ANALYZER_DESCRIPTION = 'Analyze GitHub Discussions for the current repository through Forge-managed live fetching and summary artifacts.';
+type AnalyzerDomain = 'discussions' | 'issues';
+
+interface AnalyzerPromptContext {
+  analyzerDescription: string;
+  workflowTitle: string;
+  roleName: string;
+  subjectPlural: string;
+  subjectSingularLower: string;
+  counterpartPlural: string;
+  narrowingHint: string;
+}
+
+function getAnalyzerDomain(entry: SummonableEntry): AnalyzerDomain {
+  if (entry.metadata && typeof entry.metadata === 'object' && entry.metadata.analyzerDomain === 'issues') {
+    return 'issues';
+  }
+  return 'discussions';
+}
+
+function getAnalyzerPromptContext(entry: SummonableEntry): AnalyzerPromptContext {
+  const domain = getAnalyzerDomain(entry);
+  if (domain === 'issues') {
+    return {
+      analyzerDescription: 'Analyze GitHub Issues for the current repository through Forge-managed live fetching and summary artifacts.',
+      workflowTitle: 'Forge Issue Analyzer Workflow',
+      roleName: 'Forge Issue Analyzer',
+      subjectPlural: 'GitHub Issues',
+      subjectSingularLower: 'issue',
+      counterpartPlural: 'GitHub Discussions',
+      narrowingHint: 'label, state, relative windows, or explicit after/before dates',
+    };
+  }
+
+  return {
+    analyzerDescription: 'Analyze GitHub Discussions for the current repository through Forge-managed live fetching and summary artifacts.',
+    workflowTitle: 'Forge Discussion Analyzer Workflow',
+    roleName: 'Forge Discussion Analyzer',
+    subjectPlural: 'GitHub Discussions',
+    subjectSingularLower: 'discussion',
+    counterpartPlural: 'GitHub Issues',
+    narrowingHint: 'category, relative windows, or explicit after/before dates',
+  };
+}
 
 export function sanitizePlainScalar(value: string): string {
   return value
@@ -53,33 +95,37 @@ function renderManagedMarkdown(
   ].join('\n');
 }
 
-function renderDiscussionAgentPrompt(runtimeEntryCommand: string): string {
+function renderAnalyzerAgentPrompt(entry: SummonableEntry, runtimeEntryCommand: string): string {
+  const context = getAnalyzerPromptContext(entry);
+  const runCommand = `${runtimeEntryCommand} --run ${entry.id} --question "<question>"`;
+
   return [
     '<role>',
-    'You are the Forge Discussion Analyzer.',
-    'Analyze GitHub Discussions for the current repository using Forge as the only backend.',
+    `You are the ${context.roleName}.`,
+    `Analyze ${context.subjectPlural} for the current repository using Forge as the only backend.`,
     '</role>',
     '',
     '<instructions>',
-    '- Use this agent for discussion digests, triage, pattern analysis, and follow-up answers.',
-    '- If the user asks about GitHub Issues, explain that this analyzer only covers GitHub Discussions and stop.',
-    `- Run \`${runtimeEntryCommand} --run forge-discussion-analyzer --question "<question>"\` directly instead of delegating to unrelated helpers.`,
-    '- Every query must use a live fetch through Forge; never answer from local cached summaries alone.',
+    `- Use this agent for ${context.subjectSingularLower} digests, triage, pattern analysis, and follow-up answers.`,
+    `- If the user asks about ${context.counterpartPlural}, explain that this analyzer only covers ${context.subjectPlural} and stop.`,
+    `- Run \`${runCommand}\` directly instead of delegating to unrelated helpers.`,
+    `- Every query must use a live fetch through Forge; never answer from local cached ${context.subjectSingularLower} summaries alone.`,
     '- Ask for approval once for the Forge command, then let Forge handle fetch plus analysis.',
     '- Do not run npm install, repair Forge dependencies, or switch to raw GitHub API calls when Forge is available.',
     '- If Forge fails or times out because of network or GitHub API issues, report the Forge failure and stop.',
     '- Delegate data acquisition, filtering, preprocessing, and freshness handling to Forge.',
-    '- Suggest narrowing by category, relative windows, or explicit after/before dates when the user needs a smaller slice.',
+    `- Suggest narrowing by ${context.narrowingHint} when the user needs a smaller slice.`,
     '</instructions>',
   ].join('\n');
 }
 
 export function renderClaudeCommand(entry: SummonableEntry, workflowPath: string): string {
+  const context = getAnalyzerPromptContext(entry);
   const commandName = sanitizePlainScalar(getExposedSummonableName('claude', 'command', entry));
   const workflowReference = `@${workflowPath}`;
   const body = [
     '<objective>',
-    ANALYZER_DESCRIPTION,
+    context.analyzerDescription,
     '</objective>',
     '',
     '<execution_context>',
@@ -89,13 +135,13 @@ export function renderClaudeCommand(entry: SummonableEntry, workflowPath: string
     '<context>',
     '$ARGUMENTS',
     '',
-    'Ask a concrete question about GitHub Discussions for the current repository.',
+    `Ask a concrete question about ${context.subjectPlural} for the current repository.`,
     '</context>',
     '',
     '<process>',
     `Execute the workflow from ${workflowReference} end-to-end.`,
     'Preserve the live-fetch-only behavior for every query.',
-    'If the request is about GitHub Issues instead of GitHub Discussions, explain that limitation and stop.',
+    `If the request is about ${context.counterpartPlural} instead of ${context.subjectPlural}, explain that limitation and stop.`,
     '</process>',
   ].join('\n');
 
@@ -123,7 +169,7 @@ export function renderClaudeAgent(entry: SummonableEntry, runtimeEntryCommand: s
       `description: ${sanitizePlainScalar(entry.purpose)}`,
       'tools: Bash, Read',
     ],
-    renderDiscussionAgentPrompt(runtimeEntryCommand),
+    renderAnalyzerAgentPrompt(entry, runtimeEntryCommand),
     [
       '<!-- Add team- or user-specific Claude agent instructions below this line. -->',
       '<!-- Keep your custom instructions outside Forge managed markers so updates preserve them. -->',
@@ -132,14 +178,15 @@ export function renderClaudeAgent(entry: SummonableEntry, runtimeEntryCommand: s
 }
 
 export function renderClaudeWorkflow(_entry: SummonableEntry, runtimeEntryCommand: string): string {
+  const context = getAnalyzerPromptContext(_entry);
   return [
-    '# Forge Discussion Analyzer Workflow',
+    `# ${context.workflowTitle}`,
     '',
-    `Run \`${runtimeEntryCommand} --run forge-discussion-analyzer --question "$ARGUMENTS"\` as the only backend for this workflow.`,
+    `Run \`${runtimeEntryCommand} --run ${_entry.id} --question "$ARGUMENTS"\` as the only backend for this workflow.`,
     '',
     'Execution rules:',
-    '- Every query must use Forge live fetches; do not answer from local summary content alone.',
-    '- If the request is about GitHub Issues instead of GitHub Discussions, explain that this workflow only covers Discussions and stop.',
+    `- Every query must use Forge live fetches; do not answer from local ${context.subjectSingularLower} summary content alone.`,
+    `- If the request is about ${context.counterpartPlural} instead of ${context.subjectPlural}, explain that this workflow only covers ${context.subjectPlural} and stop.`,
     '- Ask for approval once for the Forge command, then let Forge handle fetch plus analysis.',
     '- Do not run npm install, repair Forge dependencies, or switch to raw GitHub API calls when Forge is available.',
     '- If Forge fails or times out because of network or GitHub API issues, report the Forge failure and stop.',
@@ -147,18 +194,19 @@ export function renderClaudeWorkflow(_entry: SummonableEntry, runtimeEntryComman
 }
 
 export function renderCodexSkill(entry: SummonableEntry, workflowPath: string): string {
+  const context = getAnalyzerPromptContext(entry);
   const skillName = sanitizePlainScalar(getExposedSummonableName('codex', 'skill', entry));
   const workflowReference = `@${workflowPath}`;
   const body = [
     '<codex_skill_adapter>',
     '## Skill Invocation',
     `- This skill is invoked by mentioning \`$${skillName}\`.`,
-    '- Treat all user text after the skill mention as the discussion question.',
-    '- If no question is provided, ask the user what they want to know about the repository GitHub Discussions.',
+    `- Treat all user text after the skill mention as the ${context.subjectSingularLower} question.`,
+    `- If no question is provided, ask the user what they want to know about the repository ${context.subjectPlural}.`,
     '</codex_skill_adapter>',
     '',
     '<objective>',
-    ANALYZER_DESCRIPTION,
+    context.analyzerDescription,
     '</objective>',
     '',
     '<execution_context>',
@@ -172,7 +220,7 @@ export function renderCodexSkill(entry: SummonableEntry, workflowPath: string): 
     '<process>',
     `Execute the workflow from ${workflowReference} end-to-end.`,
     'Preserve the live-fetch-only behavior for every query.',
-    'If the request is about GitHub Issues instead of GitHub Discussions, explain that limitation and stop.',
+    `If the request is about ${context.counterpartPlural} instead of ${context.subjectPlural}, explain that limitation and stop.`,
     '</process>',
   ].join('\n');
 
@@ -192,7 +240,7 @@ export function renderCodexSkill(entry: SummonableEntry, workflowPath: string): 
 }
 
 export function renderCodexAgent(entry: SummonableEntry, runtimeEntryCommand: string): string {
-  const body = renderDiscussionAgentPrompt(runtimeEntryCommand);
+  const body = renderAnalyzerAgentPrompt(entry, runtimeEntryCommand);
   return renderManagedMarkdown(
     [
       `name: "${sanitizePlainScalar(getExposedSummonableName('codex', 'agent', entry))}"`,
@@ -211,16 +259,18 @@ export function renderCodexAgent(entry: SummonableEntry, runtimeEntryCommand: st
 }
 
 export function renderCodexAgentToml(entry: SummonableEntry, runtimeEntryCommand: string): string {
+  const context = getAnalyzerPromptContext(entry);
+  const runCommand = `${runtimeEntryCommand} --run ${entry.id} --question "<question>"`;
   const body = [
     '<role>',
-    'You are the Forge Discussion Analyzer.',
-    'Analyze GitHub Discussions for the current repository using Forge as the only backend.',
+    `You are the ${context.roleName}.`,
+    `Analyze ${context.subjectPlural} for the current repository using Forge as the only backend.`,
     '</role>',
     '',
     '<instructions>',
-    '- Use this agent for discussion digests, triage, pattern analysis, and follow-up answers.',
-    '- If the user asks about GitHub Issues, explain that this analyzer only covers GitHub Discussions and stop.',
-    `- Run \`${runtimeEntryCommand} --run forge-discussion-analyzer --question "<question>"\` directly instead of delegating to unrelated helpers.`,
+    `- Use this agent for ${context.subjectSingularLower} digests, triage, pattern analysis, and follow-up answers.`,
+    `- If the user asks about ${context.counterpartPlural}, explain that this analyzer only covers ${context.subjectPlural} and stop.`,
+    `- Run \`${runCommand}\` directly instead of delegating to unrelated helpers.`,
     '- Every query must use a live fetch through Forge; never answer from local cached summaries alone.',
     '- Ask for approval once for the Forge command, then let Forge handle fetch plus analysis.',
     '- Do not run npm install, repair Forge dependencies, or switch to raw GitHub API calls when Forge is available.',
@@ -240,9 +290,11 @@ export function renderCodexWorkflow(_entry: SummonableEntry, runtimeEntryCommand
 }
 
 export function renderGeminiCommand(entry: SummonableEntry, workflowPath: string): string {
+  const context = getAnalyzerPromptContext(entry);
+  const backendCommand = `node "$HOME/.gemini/forge/bin/forge.mjs" --run ${entry.id} --question "<question>"`;
   const prompt = [
     '<objective>',
-    ANALYZER_DESCRIPTION,
+    context.analyzerDescription,
     '</objective>',
     '',
     '<context>',
@@ -252,12 +304,12 @@ export function renderGeminiCommand(entry: SummonableEntry, workflowPath: string
     '</context>',
     '',
     '<process>',
-    `Forge backend: node "$HOME/.gemini/forge/bin/forge.mjs" --run ${entry.id} --question "<question>"`,
-    'If $ARGUMENTS is empty or still appears as the literal placeholder "$ARGUMENTS", ask the user for a concrete GitHub Discussions question and stop.',
+    `Forge backend: ${backendCommand}`,
+    `If $ARGUMENTS is empty or still appears as the literal placeholder "$ARGUMENTS", ask the user for a concrete ${context.subjectPlural} question and stop.`,
     'Do not inspect the codebase, search the repository, or read files under ~/.gemini before deciding what to do.',
     'Run the Forge backend directly from the current repository once you have a concrete question.',
     'Preserve the live-fetch-only behavior for every query.',
-    'If the request is about GitHub Issues instead of GitHub Discussions, explain that limitation and stop.',
+    `If the request is about ${context.counterpartPlural} instead of ${context.subjectPlural}, explain that limitation and stop.`,
     'If Forge fails or times out because of network, auth, or GitHub API issues, report the Forge failure and stop.',
     '</process>',
   ].join('\n');
@@ -278,7 +330,7 @@ export function renderGeminiAgent(entry: SummonableEntry, runtimeEntryCommand: s
       '  - read_file',
       '  - run_shell_command',
     ],
-    renderDiscussionAgentPrompt(runtimeEntryCommand),
+    renderAnalyzerAgentPrompt(entry, runtimeEntryCommand),
     [
       '<!-- Add team- or user-specific Gemini agent instructions below this line. -->',
       '<!-- Keep your custom instructions outside Forge managed markers so updates preserve them. -->',

--- a/src/services/assistants/summonables.ts
+++ b/src/services/assistants/summonables.ts
@@ -47,8 +47,63 @@ export const forgeDiscussionAnalyzerEntry: SummonableEntry = {
     'Optimize for high-signal GitHub Discussion summaries and follow-up answers.',
     'Prefer the Forge-managed agent or the matching Forge skill over unrelated skill delegation.',
   ],
+  metadata: {
+    analyzerDomain: 'discussions',
+  },
+};
+
+export const forgeIssueAnalyzerEntry: SummonableEntry = {
+  id: 'forge-issue-analyzer',
+  displayName: 'Forge Issue Analyzer',
+  purpose: 'Analyze GitHub Issues for the current repository through Forge-managed live fetching and summary artifacts.',
+  instructions: [
+    'Use this agent for issue digests, triage, pattern analysis, and follow-up answers.',
+    'If the user asks about GitHub Discussions, redirect them to GitHub Issues instead of pretending this analyzer covers discussions.',
+    `Treat \`${COPILOT_RUNTIME_ENTRY}\` as the only backend for this workflow.`,
+    'Ask for approval once for the Forge command, then let Forge handle fetch plus analysis.',
+    'Do not run npm install, repair Forge dependencies, or switch to raw gh api graphql when Forge is available.',
+    'If Forge fails or times out because of network or GitHub API issues, report the Forge failure and stop instead of falling back to gh api or any other direct GitHub access.',
+    'Run the Forge command directly instead of delegating to unrelated skills or helpers.',
+    'If GitHub Copilot chooses to use a skill for this task, use only the `forge-issue-analyzer` skill that points back to the same Forge command.',
+    'Delegate data acquisition, filtering, preprocessing, and freshness handling to Forge.',
+    'Suggest narrowing by label, state, relative windows, or explicit after/before dates when the user needs a smaller slice.',
+  ].map((line) => `- ${line}`).join('\n'),
+  capabilities: [
+    {
+      name: 'Issue Digests',
+      description: 'Produces structured summaries and analysis from GitHub Issues.',
+      benefits: ['Scannable summaries', 'Question-driven follow-up analysis'],
+    },
+    {
+      name: 'Compact Context',
+      description: 'Uses live GitHub issue fetches and saves only summary artifacts to .forge.',
+      benefits: ['Lower prompt overhead', 'No durable semantic drift from cached analysis state'],
+    },
+  ],
+  commands: [
+    {
+      name: '/agent forge-issue-analyzer',
+      description: 'Select the issue analyzer agent, then ask a question.',
+      usage: `${COPILOT_RUNTIME_ENTRY} --run forge-issue-analyzer --question "<your question>"`,
+      examples: [
+        '/agent -> select forge-issue-analyzer -> "what were the major open bug patterns last week?"',
+        `${COPILOT_RUNTIME_ENTRY} --run forge-issue-analyzer --question "summarize blocked issues"`,
+      ],
+    },
+  ],
+  principles: [
+    'Keep the assistant-facing asset compact and let Forge own the operational backend.',
+    'Ground analysis in fetched sidecar artifacts, not in guessed repository state.',
+    'Request approval once for the Forge-managed action, not repeatedly for the same analysis flow.',
+    'Optimize for high-signal GitHub Issue summaries and follow-up answers.',
+    'Prefer the Forge-managed agent or the matching Forge skill over unrelated skill delegation.',
+  ],
+  metadata: {
+    analyzerDomain: 'issues',
+  },
 };
 
 export const forgeSummonableEntries: SummonableEntry[] = [
   forgeDiscussionAnalyzerEntry,
+  forgeIssueAnalyzerEntry,
 ];

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -102,7 +102,7 @@ export class GitService {
     const repository = parseGitHubRepositoryRemote(remoteUrl);
     if (!repository) {
       throw new UnsupportedGitHubRemoteError(
-        `Forge only supports GitHub remotes for discussions fetches. Current origin: ${remoteUrl}`
+        `Forge only supports GitHub remotes for live fetches. Current origin: ${remoteUrl}`
       );
     }
 

--- a/src/services/issues/analyze.ts
+++ b/src/services/issues/analyze.ts
@@ -1,0 +1,522 @@
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { IssueSummaryArtifact, PreparedIssueDigest } from '../../contracts/issues.js';
+import { IssueArtifactsRequiredError, IssuesOnlyAnalyzerError } from '../../lib/errors.js';
+import { deriveSidecarContext } from '../sidecar.js';
+import { buildPreparedIssueDigest } from './prepare.js';
+import { analyzeIssueRequestIntent, IssueAnalyzerIntent } from './request-intent.js';
+import { runIssueFetch } from './run.js';
+
+export interface RunIssueAnalyzerOptions {
+  cwd: string;
+  question: string;
+  forceRefresh?: boolean;
+  refreshAnalysis?: boolean;
+  token?: string;
+  when?: string;
+  after?: string;
+  before?: string;
+  state?: string;
+  label?: string;
+  limit?: number;
+}
+
+const DEFAULT_ANALYZER_REFRESH_LIMIT = 1000;
+
+export async function runIssueAnalyzer(options: RunIssueAnalyzerOptions): Promise<string> {
+  const intent = analyzeIssueRequestIntent({
+    question: options.question,
+    forceRefresh: options.forceRefresh,
+    refreshAnalysis: options.refreshAnalysis,
+    when: options.when,
+    after: options.after,
+    before: options.before,
+    state: options.state,
+    label: options.label,
+    limit: options.limit,
+  });
+
+  if (!intent.normalizedQuestion) {
+    throw new IssueArtifactsRequiredError('A question is required when running forge-issue-analyzer.');
+  }
+  assertIssueScopedQuestion(intent);
+
+  const digest = await fetchDigestForIntent(options, intent);
+  const answer = renderAnswer(digest, intent);
+  await persistIssueSummary(options.cwd, digest, intent, answer);
+  return answer;
+}
+
+async function fetchDigestForIntent(
+  options: RunIssueAnalyzerOptions,
+  intent: IssueAnalyzerIntent,
+): Promise<PreparedIssueDigest> {
+  const fetched = await runIssueFetch({
+    cwd: options.cwd,
+    token: options.token,
+    when: intent.parsedFilters.when,
+    after: intent.parsedFilters.after,
+    before: intent.parsedFilters.before,
+    state: intent.parsedFilters.state,
+    label: intent.parsedFilters.label,
+    dateField: intent.temporalField,
+    limit: options.limit ?? DEFAULT_ANALYZER_REFRESH_LIMIT,
+  });
+
+  return buildPreparedIssueDigest(fetched);
+}
+
+function renderAnswer(digest: PreparedIssueDigest, intent: IssueAnalyzerIntent): string {
+  const selectedRecords = selectRelevantRecords(digest, intent);
+  const records = shouldLimitRenderedRecords(intent) ? selectedRecords.slice(0, 12) : selectedRecords;
+  const countSummary = deriveCountSummary(selectedRecords, intent);
+  const labelGroups = groupRecordsByLabel(records);
+  const stateCounts = countBy(selectedRecords.map((record) => record.state));
+
+  if (intent.answerShape.wantsLabelHealth && intent.parsedFilters.label) {
+    return renderLabelHealthAnswer(digest, intent, selectedRecords);
+  }
+
+  const lines: string[] = [
+    `# GitHub Issues Digest: ${digest.repository.owner}/${digest.repository.name}`,
+    '',
+    `**Question:** ${intent.question}  `,
+    `**Source Run:** \`${digest.sourceRunId}\`  `,
+    `**Data Prepared:** ${digest.timestamp}  `,
+    `**Total Issues:** ${digest.totals.issues}  `,
+    `**Answer Source:** ${describeAnswerSource(intent)}  `,
+    '',
+  ];
+
+  if (countSummary) {
+    lines.push('## Count Summary');
+    lines.push(`**Counted Issues:** ${countSummary.count}  `);
+    lines.push(`**Basis:** ${countSummary.basis}  `);
+    lines.push('');
+  }
+
+  lines.push('## State Summary');
+  lines.push('| State | Issues |');
+  lines.push('| :--- | ---: |');
+  for (const [state, count] of Object.entries(stateCounts).sort((left, right) => right[1] - left[1])) {
+    lines.push(`| ${state} | ${count} |`);
+  }
+  if (Object.keys(stateCounts).length === 0) {
+    lines.push('| none | 0 |');
+  }
+  lines.push('');
+
+  lines.push('## Label Summary');
+  lines.push('| Label | Issues | Status Breakdown |');
+  lines.push('| :--- | ---: | :--- |');
+  for (const [label, groupedRecords] of labelGroups) {
+    lines.push(
+      `| ${label} | ${groupedRecords.length} | ${formatCountMap(countBy(groupedRecords.map((record) => record.status)))} |`,
+    );
+  }
+  if (labelGroups.size === 0) {
+    lines.push('| none | 0 | n/a |');
+  }
+  lines.push('');
+
+  if (labelGroups.size === 0) {
+    lines.push('## Matching Issues');
+    lines.push('No issues matched the requested scope in the live fetched issues.');
+    lines.push('');
+  }
+
+  for (const [label, groupedRecords] of labelGroups) {
+    lines.push(`## ${label}`);
+    lines.push(`**Issues:** ${groupedRecords.length}  `);
+    lines.push(`**States:** ${formatCountMap(countBy(groupedRecords.map((record) => record.state)))}  `);
+    lines.push('');
+
+    for (const record of groupedRecords) {
+      lines.push(`### ${record.title} (#${record.number})`);
+      lines.push(`- **State:** ${record.state}`);
+      lines.push(`- **Status:** ${record.status}`);
+      lines.push(`- **Kind:** ${record.kind}`);
+      lines.push(`- **Issue:** ${record.issue}`);
+      lines.push(`- **Key Context:** ${record.keyContext.join(' | ') || 'No additional context extracted.'}`);
+      lines.push(`- **Resolution:** ${record.resolution}`);
+      lines.push(`- **Action Items:** ${record.actionItems.join('; ')}`);
+      lines.push('');
+    }
+  }
+
+  if (intent.answerShape.wantsPatterns) {
+    lines.push('## Pattern Analysis', '');
+    lines.push('**Derived Themes:**');
+    renderThemeSummary(deriveThemeGroups(selectedRecords)).forEach((line) => lines.push(line));
+    lines.push('');
+  }
+
+  if (intent.answerShape.wantsEffectiveness) {
+    lines.push('## Engineering Effectiveness Analysis', '');
+    lines.push('#### Strengths ✅');
+    lines.push(`- ${(stateCounts.closed ?? 0)} issues are closed.`);
+    lines.push('');
+    lines.push('#### Weaknesses ❌');
+    lines.push(`- ${(stateCounts.open ?? 0)} issues are still open.`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
+}
+
+function selectRelevantRecords(
+  digest: PreparedIssueDigest,
+  intent: IssueAnalyzerIntent,
+): PreparedIssueDigest['records'] {
+  const recordsInWindow = digest.records.filter((record) => matchesIntentWindow(record, intent));
+  const recordsInLabel = intent.parsedFilters.label
+    ? recordsInWindow.filter((record) => {
+        const normalizedLabel = intent.parsedFilters.label?.toLowerCase();
+        return record.labels.some((label) => label.toLowerCase() === normalizedLabel);
+      })
+    : recordsInWindow;
+  const recordsInState = intent.parsedFilters.state === 'all'
+    ? recordsInLabel
+    : recordsInLabel.filter((record) => record.state === intent.parsedFilters.state);
+
+  if (!shouldUseKeywordFiltering(intent)) {
+    return recordsInState;
+  }
+
+  return filterRelevantRecords(recordsInState, intent.normalizedQuestion);
+}
+
+function shouldUseKeywordFiltering(intent: IssueAnalyzerIntent): boolean {
+  if (intent.answerShape.wantsLabelHealth || intent.answerShape.wantsCounts) {
+    return false;
+  }
+  if (intent.parsedFilters.label || intent.parsedFilters.when || intent.parsedFilters.after || intent.parsedFilters.before) {
+    return false;
+  }
+  if (intent.parsedFilters.state !== 'all') {
+    return false;
+  }
+  return true;
+}
+
+function shouldLimitRenderedRecords(intent: IssueAnalyzerIntent): boolean {
+  if (intent.answerShape.wantsLabelHealth || intent.answerShape.wantsCounts || intent.answerShape.wantsPatterns) {
+    return false;
+  }
+  if (intent.parsedFilters.label || intent.parsedFilters.when || intent.parsedFilters.after || intent.parsedFilters.before) {
+    return false;
+  }
+  if (intent.parsedFilters.state !== 'all') {
+    return false;
+  }
+  if (/\b(all issues|grouped by label|all labels|summary)\b/.test(intent.normalizedQuestion)) {
+    return false;
+  }
+  return true;
+}
+
+function filterRelevantRecords(records: PreparedIssueDigest['records'], question: string) {
+  const keywords = question
+    .split(/\W+/)
+    .map((token) => token.toLowerCase())
+    .filter((token) => token.length >= 4);
+
+  if (keywords.length === 0) {
+    return records;
+  }
+
+  const scored = records.map((record) => {
+    const haystack = `${record.title} ${record.issue} ${record.resolution} ${record.labels.join(' ')} ${record.kind}`.toLowerCase();
+    const score = keywords.reduce((acc, keyword) => acc + (haystack.includes(keyword) ? 1 : 0), 0);
+    return { record, score };
+  });
+
+  const matching = scored.filter((entry) => entry.score > 0).sort((left, right) => right.score - left.score);
+  return matching.length > 0 ? matching.map((entry) => entry.record) : records;
+}
+
+function matchesIntentWindow(record: PreparedIssueDigest['records'][number], intent: IssueAnalyzerIntent): boolean {
+  if (!intent.parsedFilters.after && !intent.parsedFilters.before) {
+    return true;
+  }
+
+  const timestamp = new Date(intent.temporalField === 'createdAt' ? record.createdAt : record.updatedAt);
+  if (Number.isNaN(timestamp.getTime())) {
+    return false;
+  }
+
+  if (intent.parsedFilters.after && timestamp < new Date(intent.parsedFilters.after)) {
+    return false;
+  }
+  if (intent.parsedFilters.before && timestamp > new Date(intent.parsedFilters.before)) {
+    return false;
+  }
+
+  return true;
+}
+
+function assertIssueScopedQuestion(intent: IssueAnalyzerIntent): void {
+  if (intent.scope !== 'discussions') {
+    return;
+  }
+
+  throw new IssuesOnlyAnalyzerError(
+    ['Forge analyzes GitHub Issues only.', `Want "${intent.redirectQuestion ?? intent.question}" instead?`].join('\n'),
+  );
+}
+
+function deriveCountSummary(
+  records: PreparedIssueDigest['records'],
+  intent: IssueAnalyzerIntent,
+): { count: number; basis: string; records: PreparedIssueDigest['records'] } | null {
+  if (!intent.answerShape.wantsCounts) {
+    return null;
+  }
+
+  return {
+    count: records.length,
+    basis: describeCountBasis(intent),
+    records,
+  };
+}
+
+async function persistIssueSummary(
+  cwd: string,
+  digest: PreparedIssueDigest,
+  intent: IssueAnalyzerIntent,
+  answer: string,
+): Promise<void> {
+  const context = deriveSidecarContext(cwd);
+  const timestamp = new Date().toISOString();
+  const summaryId = `${digest.sourceRunId}-summary-${timestamp.replace(/[:.]/g, '-')}`;
+  const summaryBasePath = path.join(context.sidecarPath, 'issues', 'summary');
+  const runsPath = path.join(summaryBasePath, 'runs');
+  const runDir = path.join(runsPath, summaryId);
+  await mkdir(runDir, { recursive: true });
+
+  const selectedRecords = selectRelevantRecords(digest, intent);
+  const summary: IssueSummaryArtifact = {
+    version: '1.0',
+    id: summaryId,
+    timestamp,
+    question: intent.question,
+    repository: digest.repository,
+    sourceRunId: digest.sourceRunId,
+    source: 'live-fetch',
+    filters: {
+      when: intent.parsedFilters.when,
+      after: intent.parsedFilters.after,
+      before: intent.parsedFilters.before,
+      state: intent.parsedFilters.state,
+      label: intent.parsedFilters.label,
+      dateField: intent.parsedFilters.dateField,
+    },
+    issueCount: selectedRecords.length,
+    stateBreakdown: countBy(selectedRecords.map((record) => record.state)),
+    labelBreakdown: countBy(selectedRecords.flatMap((record) => record.labels.length > 0 ? record.labels : ['No Label'])),
+    answer,
+  };
+
+  await writeFile(path.join(runDir, 'summary.json'), JSON.stringify(summary, null, 2), 'utf8');
+  await writeFile(path.join(runDir, 'question.txt'), `${intent.question.trim()}\n`, 'utf8');
+  await writeFile(path.join(runDir, 'answer.md'), answer, 'utf8');
+  await writeFile(path.join(summaryBasePath, 'latest.json'), JSON.stringify(summary, null, 2), 'utf8');
+  await writeFile(path.join(summaryBasePath, 'latest.md'), answer, 'utf8');
+}
+
+function describeAnswerSource(intent: IssueAnalyzerIntent): string {
+  void intent;
+  return 'live fetch';
+}
+
+function describeCountBasis(intent: IssueAnalyzerIntent): string {
+  const segments: string[] = [];
+  if (intent.parsedFilters.state && intent.parsedFilters.state !== 'all') {
+    segments.push(`state ${intent.parsedFilters.state}`);
+  }
+  if (intent.parsedFilters.label) {
+    segments.push(`label ${intent.parsedFilters.label}`);
+  }
+  if (intent.parsedFilters.when) {
+    segments.push(intent.parsedFilters.when);
+  }
+  if (intent.parsedFilters.after) {
+    segments.push(`after ${intent.parsedFilters.after}`);
+  }
+  if (intent.parsedFilters.before) {
+    segments.push(`before ${intent.parsedFilters.before}`);
+  }
+
+  return segments.length > 0
+    ? `${intent.temporalField} filtered by ${segments.join(' and ')}`
+    : `${intent.temporalField} across the live fetched issues`;
+}
+
+function renderLabelHealthAnswer(
+  digest: PreparedIssueDigest,
+  intent: IssueAnalyzerIntent,
+  records: PreparedIssueDigest['records'],
+): string {
+  const label = intent.parsedFilters.label ?? records[0]?.labels[0] ?? 'Selected Label';
+  const stateCounts = countBy(records.map((record) => record.state));
+  const unresolved = records.filter((record) => record.state === 'open' || record.status === 'blocked');
+
+  const lines: string[] = [
+    `# GitHub Issues Label Health: ${label}`,
+    '',
+    `**Question:** ${intent.question}  `,
+    `**Source Run:** \`${digest.sourceRunId}\`  `,
+    `**Answer Source:** ${describeAnswerSource(intent)}  `,
+    `**Total Issues:** ${records.length}  `,
+    '',
+    '## State Breakdown',
+    `- open: ${stateCounts.open ?? 0}`,
+    `- closed: ${stateCounts.closed ?? 0}`,
+    '',
+    '## Major Themes',
+    ...renderThemeSummary(deriveThemeGroups(records)),
+    '',
+  ];
+
+  if (unresolved.length === 0) {
+    lines.push('## Open Or Blocked Issues');
+    lines.push('No open or blocked issues in this label.');
+    lines.push('');
+  } else {
+    lines.push('## Open Or Blocked Issues', '');
+    for (const record of unresolved) {
+      lines.push(`### ${record.title} (#${record.number})`);
+      lines.push(`- **State:** ${record.state}`);
+      lines.push(`- **Status:** ${record.status}`);
+      lines.push(`- **Issue:** ${record.issue}`);
+      lines.push(`- **Resolution:** ${record.resolution}`);
+      lines.push(`- **Action Items:** ${record.actionItems.join('; ')}`);
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function deriveThemeGroups(
+  records: PreparedIssueDigest['records'],
+): Map<string, PreparedIssueDigest['records']> {
+  const grouped = new Map<string, PreparedIssueDigest['records']>();
+  const tokenFrequencies = countBy(records.flatMap((record) => extractThemeTokens(record)));
+
+  for (const record of records) {
+    const theme = inferThemeLabel(record, tokenFrequencies);
+    const existing = grouped.get(theme) ?? [];
+    existing.push(record);
+    grouped.set(theme, existing);
+  }
+  return new Map([...grouped.entries()].sort((left, right) => right[1].length - left[1].length));
+}
+
+function renderThemeSummary(
+  themeGroups: Map<string, PreparedIssueDigest['records']>,
+): string[] {
+  const lines: string[] = [];
+  for (const [theme, themeRecords] of themeGroups) {
+    const sampleTitles = themeRecords.slice(0, 3).map((record) => `#${record.number} ${record.title}`).join('; ');
+    lines.push(`- ${theme}: ${themeRecords.length} issue(s)${sampleTitles ? ` — ${sampleTitles}` : ''}`);
+  }
+  return lines;
+}
+
+function inferThemeLabel(
+  record: PreparedIssueDigest['records'][number],
+  tokenFrequencies: Record<string, number>,
+): string {
+  const tokens = extractThemeTokens(record);
+  const rankedToken = [...new Set(tokens)]
+    .sort((left, right) => {
+      return (tokenFrequencies[right] ?? 0) - (tokenFrequencies[left] ?? 0) || left.localeCompare(right);
+    })[0];
+
+  if (rankedToken) {
+    return toTitleCase(rankedToken);
+  }
+
+  if (record.labels.length > 0) {
+    return record.labels[0]!;
+  }
+
+  const fallback = record.title.trim();
+  return fallback.length > 0 ? fallback : 'General';
+}
+
+function extractThemeTokens(record: PreparedIssueDigest['records'][number]): string[] {
+  const rawTokens = `${record.title} ${record.issue}`
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4);
+
+  return rawTokens.filter((token) => !THEME_STOP_WORDS.has(token));
+}
+
+const THEME_STOP_WORDS = new Set([
+  'about',
+  'after',
+  'because',
+  'been',
+  'between',
+  'issue',
+  'issues',
+  'from',
+  'have',
+  'into',
+  'last',
+  'looking',
+  'question',
+  'questions',
+  'reported',
+  'status',
+  'their',
+  'there',
+  'these',
+  'this',
+  'those',
+  'week',
+  'with',
+]);
+
+function toTitleCase(value: string): string {
+  if (!value) {
+    return value;
+  }
+
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function groupRecordsByLabel(
+  records: PreparedIssueDigest['records'],
+): Map<string, PreparedIssueDigest['records']> {
+  const grouped = new Map<string, PreparedIssueDigest['records']>();
+  const sorted = [...records].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+
+  for (const record of sorted) {
+    const labels = record.labels.length > 0 ? record.labels : ['No Label'];
+    for (const label of labels) {
+      const existing = grouped.get(label) ?? [];
+      existing.push(record);
+      grouped.set(label, existing);
+    }
+  }
+
+  return new Map([...grouped.entries()].sort((left, right) => right[1].length - left[1].length));
+}
+
+function countBy(values: string[]): Record<string, number> {
+  return values.reduce<Record<string, number>>((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function formatCountMap(values: Record<string, number>): string {
+  return Object.entries(values)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([label, count]) => `${label}: ${count}`)
+    .join(', ');
+}

--- a/src/services/issues/fetch.ts
+++ b/src/services/issues/fetch.ts
@@ -1,0 +1,151 @@
+import { IssueFilters, IssueRecord } from '../../contracts/issues.js';
+import { GitHubRepositoryRef } from '../../contracts/discussions.js';
+import { GitHubIssuesFetchError } from '../../lib/errors.js';
+import { matchesIssueWindow } from './filters.js';
+
+const GITHUB_ISSUES_PAGE_SIZE = 100;
+
+interface GitHubIssueApiRecord {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+  state: 'open' | 'closed';
+  user?: {
+    login?: string | null;
+  } | null;
+  labels: Array<{
+    name?: string | null;
+  }>;
+  body?: string | null;
+  comments: number;
+  pull_request?: Record<string, unknown>;
+}
+
+export interface FetchGitHubIssuesOptions {
+  repository: GitHubRepositoryRef;
+  token: string;
+  filters: IssueFilters;
+}
+
+export interface FetchGitHubIssuesResult {
+  issues: IssueRecord[];
+  pageInfo: {
+    hasNextPage: boolean;
+    fetchedPages: number;
+    nextPage?: number;
+  };
+}
+
+export async function fetchGitHubIssues(
+  options: FetchGitHubIssuesOptions,
+): Promise<FetchGitHubIssuesResult> {
+  const collected: IssueRecord[] = [];
+  let page = 1;
+  let hasNextPage = true;
+  let fetchedPages = 0;
+
+  while (hasNextPage && collected.length < options.filters.limit) {
+    fetchedPages += 1;
+    const remaining = options.filters.limit - collected.length;
+    const pageSize = Math.min(GITHUB_ISSUES_PAGE_SIZE, remaining);
+
+    const response = await fetchIssuesPage(options, page, pageSize);
+    const normalized = response
+      .filter((issue) => !issue.pull_request)
+      .map((issue): IssueRecord => ({
+        id: String(issue.id),
+        number: issue.number,
+        title: issue.title,
+        url: issue.html_url,
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
+        closedAt: issue.closed_at ?? null,
+        state: issue.state,
+        author: issue.user?.login ?? undefined,
+        labels: issue.labels.map((label) => label.name?.trim()).filter((value): value is string => Boolean(value)),
+        bodyText: issue.body ?? '',
+        commentsCount: issue.comments,
+      }))
+      .filter((issue) => matchesIssueWindow(issue[options.filters.dateField], options.filters))
+      .filter((issue) => matchesLabelFilter(issue, options.filters.label));
+
+    collected.push(...normalized);
+
+    hasNextPage = response.length === pageSize;
+    page += 1;
+
+    if (options.filters.after) {
+      const oldestSeen = response.at(-1)?.[toApiDateField(options.filters.dateField)];
+      if (oldestSeen && new Date(oldestSeen) < new Date(options.filters.after)) {
+        break;
+      }
+    }
+  }
+
+  return {
+    issues: collected.slice(0, options.filters.limit),
+    pageInfo: {
+      hasNextPage,
+      fetchedPages,
+      nextPage: hasNextPage ? page : undefined,
+    },
+  };
+}
+
+async function fetchIssuesPage(
+  options: FetchGitHubIssuesOptions,
+  page: number,
+  perPage: number,
+): Promise<GitHubIssueApiRecord[]> {
+  const params = new URLSearchParams({
+    state: options.filters.state,
+    per_page: String(perPage),
+    page: String(page),
+    sort: options.filters.dateField === 'createdAt' ? 'created' : 'updated',
+    direction: 'desc',
+  });
+  const url = `https://api.github.com/repos/${options.repository.owner}/${options.repository.name}/issues?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${options.token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new GitHubIssuesFetchError(await buildIssueFetchErrorMessage(response));
+  }
+
+  return (await response.json()) as GitHubIssueApiRecord[];
+}
+
+async function buildIssueFetchErrorMessage(response: Response): Promise<string> {
+  const payload = (await response.json().catch(() => null)) as
+    | {
+        message?: string;
+      }
+    | null;
+
+  if (payload?.message) {
+    return payload.message;
+  }
+
+  return 'GitHub issues request failed.';
+}
+
+function toApiDateField(dateField: IssueFilters['dateField']): 'created_at' | 'updated_at' {
+  return dateField === 'createdAt' ? 'created_at' : 'updated_at';
+}
+
+function matchesLabelFilter(issue: IssueRecord, labelFilter?: string): boolean {
+  if (!labelFilter) {
+    return true;
+  }
+
+  const normalized = labelFilter.trim().toLowerCase();
+  return issue.labels.some((label) => label.toLowerCase() === normalized);
+}

--- a/src/services/issues/filters.ts
+++ b/src/services/issues/filters.ts
@@ -1,0 +1,150 @@
+import { IssueFilters } from '../../contracts/issues.js';
+import { UserFacingError } from '../../lib/errors.js';
+
+export interface IssueFilterInput {
+  when?: string;
+  after?: string;
+  before?: string;
+  state?: string;
+  label?: string;
+  dateField?: 'createdAt' | 'updatedAt';
+  limit?: number;
+  now?: Date;
+}
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function normalizeIssueFilters(input: IssueFilterInput = {}): IssueFilters {
+  const now = input.now ?? new Date();
+  const limit = normalizeLimit(input.limit);
+  const filters: IssueFilters = {
+    state: normalizeIssueState(input.state),
+    dateField: input.dateField ?? inferDefaultDateField(input),
+    limit,
+  };
+
+  if (input.label?.trim()) {
+    filters.label = input.label.trim();
+  }
+
+  if (input.when) {
+    const when = input.when.trim().toLowerCase();
+    switch (when) {
+      case 'today':
+        filters.when = 'today';
+        filters.after = startOfDay(now).toISOString();
+        filters.before = now.toISOString();
+        break;
+      case 'yesterday': {
+        filters.when = 'yesterday';
+        const yesterday = new Date(startOfDay(now).getTime() - DAY_IN_MS);
+        filters.after = yesterday.toISOString();
+        filters.before = startOfDay(now).toISOString();
+        break;
+      }
+      case 'last week':
+      case 'last-week':
+      case 'last_week':
+      case 'last 1 week':
+      case 'in the last week':
+      case 'in the last 1 week':
+      case 'past week':
+      case 'past 1 week':
+      case 'last 7 days':
+      case 'past 7 days':
+        filters.when = 'last-week';
+        filters.after = startOfDay(new Date(now.getTime() - (7 * DAY_IN_MS))).toISOString();
+        filters.before = now.toISOString();
+        break;
+      default:
+        throw new UserFacingError(
+          `Unsupported --when value "${input.when}". Use today, yesterday, or last-week.`,
+        );
+    }
+  }
+
+  if (input.after) {
+    filters.after = normalizeDateBoundary(input.after, 'start');
+  }
+
+  if (input.before) {
+    filters.before = normalizeDateBoundary(input.before, 'end');
+  }
+
+  if (filters.after && filters.before && new Date(filters.after) > new Date(filters.before)) {
+    throw new UserFacingError('The issues filter "after" date must be earlier than or equal to "before".');
+  }
+
+  return filters;
+}
+
+export function matchesIssueWindow(timestampValue: string, filters: IssueFilters): boolean {
+  const timestamp = new Date(timestampValue).getTime();
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+
+  if (filters.after && timestamp < new Date(filters.after).getTime()) {
+    return false;
+  }
+
+  if (filters.before && timestamp > new Date(filters.before).getTime()) {
+    return false;
+  }
+
+  return true;
+}
+
+function inferDefaultDateField(input: IssueFilterInput): 'createdAt' | 'updatedAt' {
+  if (input.when || input.after || input.before) {
+    return 'createdAt';
+  }
+  return 'updatedAt';
+}
+
+function normalizeIssueState(state?: string): IssueFilters['state'] {
+  if (!state?.trim()) {
+    return 'all';
+  }
+
+  const normalized = state.trim().toLowerCase();
+  if (normalized === 'open' || normalized === 'closed' || normalized === 'all') {
+    return normalized;
+  }
+
+  throw new UserFacingError(`Unsupported issue state "${state}". Use open, closed, or all.`);
+}
+
+function normalizeLimit(limit?: number): number {
+  if (limit === undefined) {
+    return 500;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 5000) {
+    throw new UserFacingError('Issue fetch limit must be an integer between 1 and 5000.');
+  }
+
+  return limit;
+}
+
+function normalizeDateBoundary(raw: string, mode: 'start' | 'end'): string {
+  const trimmed = raw.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const date = new Date(`${trimmed}T00:00:00.000Z`);
+    if (mode === 'end') {
+      date.setUTCHours(23, 59, 59, 999);
+    }
+    return date.toISOString();
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new UserFacingError(`Invalid date value "${raw}". Use YYYY-MM-DD or a valid ISO timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+}

--- a/src/services/issues/prepare.ts
+++ b/src/services/issues/prepare.ts
@@ -1,0 +1,150 @@
+import {
+  IssueKind,
+  IssueRun,
+  IssueStatus,
+  PreparedIssueDigest,
+  PreparedIssueRecord,
+} from '../../contracts/issues.js';
+
+export function buildPreparedIssueDigest(run: IssueRun): PreparedIssueDigest {
+  const records = run.issues.map((issue) => buildPreparedRecord(issue));
+
+  return {
+    version: '1.0',
+    id: `${run.id}-analysis`,
+    sourceRunId: run.id,
+    timestamp: new Date().toISOString(),
+    repository: run.repository,
+    filters: run.filters,
+    totals: {
+      issues: records.length,
+      states: countBy(records.map((record) => record.state)),
+      statuses: countBy(records.map((record) => record.status)),
+      kinds: countBy(records.map((record) => record.kind)),
+      labels: countBy(records.flatMap((record) => record.labels.length > 0 ? record.labels : ['No Label'])),
+    },
+    records,
+  };
+}
+
+function buildPreparedRecord(issue: IssueRun['issues'][number]): PreparedIssueRecord {
+  const searchableText = buildSearchableText(issue);
+  const kind = classifyIssueKind(issue.title, issue.labels, searchableText);
+  const status = classifyIssueStatus(issue.state, searchableText);
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    labels: issue.labels,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    state: issue.state,
+    status,
+    kind,
+    issue: truncateSentence(searchableText, 220),
+    resolution: inferResolution(issue.state, status),
+    keyContext: extractKeyContext(searchableText),
+    actionItems: inferActionItems(issue.state, status, kind),
+    teamMentions: extractTeamMentions(searchableText),
+    searchableText,
+  };
+}
+
+function classifyIssueKind(title: string, labels: string[], body: string): IssueKind {
+  const labelsLower = labels.map((label) => label.toLowerCase());
+  const haystack = `${title} ${body}`.toLowerCase();
+
+  if (labelsLower.some((label) => label.includes('bug'))) return 'bug';
+  if (labelsLower.some((label) => label.includes('feature') || label.includes('enhancement'))) return 'feature-request';
+  if (labelsLower.some((label) => label.includes('doc'))) return 'documentation';
+  if (labelsLower.some((label) => label.includes('chore') || label.includes('maintenance') || label.includes('refactor'))) {
+    return 'maintenance';
+  }
+  if (labelsLower.some((label) => label.includes('question') || label.includes('support'))) return 'question';
+
+  if (haystack.includes('bug') || haystack.includes('error') || haystack.includes('fail')) return 'bug';
+  if (haystack.includes('feature') || haystack.includes('enhancement') || haystack.includes('request')) return 'feature-request';
+  if (haystack.includes('doc') || haystack.includes('documentation')) return 'documentation';
+  if (haystack.includes('question') || haystack.includes('how do')) return 'question';
+  return 'task';
+}
+
+function classifyIssueStatus(state: 'open' | 'closed', body: string): IssueStatus {
+  if (state === 'closed') {
+    return 'closed';
+  }
+
+  const haystack = body.toLowerCase();
+  if (haystack.includes('blocked') || haystack.includes('waiting on')) {
+    return 'blocked';
+  }
+  if (haystack.includes('in progress') || haystack.includes('wip')) {
+    return 'in-progress';
+  }
+  return 'open';
+}
+
+function inferResolution(state: 'open' | 'closed', status: IssueStatus): string {
+  if (state === 'closed') {
+    return 'Issue is closed and appears resolved or intentionally completed.';
+  }
+  if (status === 'blocked') {
+    return 'Issue appears blocked on an external dependency or pending action.';
+  }
+  if (status === 'in-progress') {
+    return 'Issue appears in progress but still open.';
+  }
+  return 'Issue remains open with no explicit closure signal.';
+}
+
+function extractKeyContext(body: string): string[] {
+  return normalizeWhitespace(body)
+    .split('.')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+}
+
+function buildSearchableText(issue: IssueRun['issues'][number]): string {
+  const segments = [
+    issue.title,
+    issue.bodyText,
+    issue.labels.join(' '),
+  ];
+  return normalizeWhitespace(segments.filter(Boolean).join('. '));
+}
+
+function extractTeamMentions(body: string): string[] {
+  const matches = body.toLowerCase().match(/@[a-z0-9][a-z0-9-_]*/g) ?? [];
+  return [...new Set(matches)];
+}
+
+function inferActionItems(state: 'open' | 'closed', status: IssueStatus, kind: IssueKind): string[] {
+  if (state === 'closed') {
+    return ['No immediate action required'];
+  }
+  if (status === 'blocked') {
+    return ['Track blocker owner', 'Revisit after dependency clears'];
+  }
+  if (kind === 'documentation') {
+    return ['Consider documentation update'];
+  }
+  return ['Confirm owner', 'Define next implementation step'];
+}
+
+function countBy(values: string[]): Record<string, number> {
+  return values.reduce<Record<string, number>>((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncateSentence(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3).trimEnd()}...`;
+}

--- a/src/services/issues/request-intent.ts
+++ b/src/services/issues/request-intent.ts
@@ -1,0 +1,278 @@
+import { IssueFilters } from '../../contracts/issues.js';
+import { normalizeIssueFilters } from './filters.js';
+
+export interface IssueAnalyzerIntentOptions {
+  question: string;
+  forceRefresh?: boolean;
+  refreshAnalysis?: boolean;
+  when?: string;
+  after?: string;
+  before?: string;
+  state?: string;
+  label?: string;
+  limit?: number;
+}
+
+export interface IssueAnalyzerIntent {
+  question: string;
+  normalizedQuestion: string;
+  scope: 'issues' | 'discussions';
+  refreshMode: 'fetch';
+  refreshReason:
+    | 'explicit-force-refresh'
+    | 'explicit-refresh-analysis'
+    | 'current-status-question'
+    | 'time-scoped-question'
+    | 'default-live-query';
+  parsedFilters: IssueFilters;
+  temporalField: 'createdAt' | 'updatedAt';
+  answerShape: {
+    wantsCounts: boolean;
+    wantsPatterns: boolean;
+    wantsEffectiveness: boolean;
+    wantsLabelHealth: boolean;
+  };
+  redirectQuestion?: string;
+}
+
+export function analyzeIssueRequestIntent(
+  options: IssueAnalyzerIntentOptions,
+): IssueAnalyzerIntent {
+  const question = options.question.trim();
+  const normalizedQuestion = question.toLowerCase();
+  const scope = detectScope(normalizedQuestion);
+
+  const extractedFilters = extractQuestionFilters(question, normalizedQuestion);
+  const temporalField = detectTemporalField(normalizedQuestion, extractedFilters);
+  const chosenLabel = options.label ?? extractedFilters.label;
+  const chosenState = options.state ?? extractedFilters.state;
+  const parsedFilters = normalizeIssueFilters({
+    when: options.when ?? extractedFilters.when,
+    after: options.after ?? extractedFilters.after,
+    before: options.before ?? extractedFilters.before,
+    label: chosenLabel,
+    state: chosenState,
+    dateField: temporalField,
+    limit: options.limit,
+  });
+
+  const refreshReason = resolveRefreshReason({
+    normalizedQuestion,
+    forceRefresh: options.forceRefresh,
+    refreshAnalysis: options.refreshAnalysis,
+    filters: parsedFilters,
+  });
+
+  return {
+    question,
+    normalizedQuestion,
+    scope,
+    refreshMode: 'fetch',
+    refreshReason,
+    parsedFilters,
+    temporalField,
+    answerShape: {
+      wantsCounts: /\b(count|how many|number of|total)\b/.test(normalizedQuestion),
+      wantsPatterns: ['pattern', 'trend', 'common', 'theme', 'recurring', 'gap', 'gaps'].some((keyword) =>
+        normalizedQuestion.includes(keyword),
+      ),
+      wantsEffectiveness: ['effectiveness', 'stability', 'closure rate', 'triage quality', 'response time'].some(
+        (keyword) => normalizedQuestion.includes(keyword),
+      ),
+      wantsLabelHealth: hasCurrentStatusIntent(normalizedQuestion) && Boolean(parsedFilters.label),
+    },
+    redirectQuestion: scope === 'discussions' ? question.replace(/\bdiscussions?\b/gi, 'issues') : undefined,
+  };
+}
+
+function detectScope(normalizedQuestion: string): 'issues' | 'discussions' {
+  const mentionsDiscussions = /\bdiscussions?\b/.test(normalizedQuestion);
+  const mentionsIssues = /\bissues?\b/.test(normalizedQuestion);
+  if (mentionsDiscussions && !mentionsIssues) {
+    return 'discussions';
+  }
+  return 'issues';
+}
+
+function detectTemporalField(
+  normalizedQuestion: string,
+  extractedFilters: { when?: string; after?: string; before?: string; label?: string; state?: string },
+): 'createdAt' | 'updatedAt' {
+  if (/\b(updated|activity|active|recent activity)\b/.test(normalizedQuestion)) {
+    return 'updatedAt';
+  }
+  if (/\b(created|opened|open)\b/.test(normalizedQuestion)) {
+    return 'createdAt';
+  }
+  if (extractedFilters.when || extractedFilters.after || extractedFilters.before) {
+    return 'createdAt';
+  }
+  return 'updatedAt';
+}
+
+function resolveRefreshReason(input: {
+  normalizedQuestion: string;
+  forceRefresh?: boolean;
+  refreshAnalysis?: boolean;
+  filters: IssueFilters;
+}): IssueAnalyzerIntent['refreshReason'] {
+  if (input.forceRefresh) {
+    return 'explicit-force-refresh';
+  }
+  if (input.refreshAnalysis) {
+    return 'explicit-refresh-analysis';
+  }
+  if (hasCurrentStatusIntent(input.normalizedQuestion)) {
+    return 'current-status-question';
+  }
+  if (hasExplicitTimeScope(input.normalizedQuestion, input.filters)) {
+    return 'time-scoped-question';
+  }
+  return 'default-live-query';
+}
+
+function hasCurrentStatusIntent(normalizedQuestion: string): boolean {
+  if (/\b(current status|latest status|current state|latest state|up to date)\b/.test(normalizedQuestion)) {
+    return true;
+  }
+  if (/\bhow\s+is\s+.+\s+looking\b/.test(normalizedQuestion) || /\bhow\s+are\s+.+\s+looking\b/.test(normalizedQuestion)) {
+    return true;
+  }
+  if (/\bhow\s+(?:is|are)\s+.+\s+(?:doing|going|performing)\b/.test(normalizedQuestion)) {
+    return true;
+  }
+
+  const currentnessWord = /\b(current|latest|fresh)\b/.test(normalizedQuestion);
+  const statusWord = /\b(status|state|standing|situation|update|updates)\b/.test(normalizedQuestion);
+  return currentnessWord && statusWord;
+}
+
+function hasExplicitTimeScope(normalizedQuestion: string, filters: IssueFilters): boolean {
+  if (filters.when || filters.after || filters.before) {
+    return true;
+  }
+
+  return (
+    /\bbetween\b/.test(normalizedQuestion) ||
+    /\b(since|after|before|from|during)\b/.test(normalizedQuestion) ||
+    /\b(today|yesterday|last week|last-week)\b/.test(normalizedQuestion)
+  );
+}
+
+function extractQuestionFilters(
+  question: string,
+  normalizedQuestion: string,
+): { when?: string; after?: string; before?: string; label?: string; state?: string } {
+  const when = extractRelativeWindow(normalizedQuestion);
+  const between = extractBetweenRange(question);
+  return {
+    when,
+    after:
+      between?.after ??
+      extractSingleDate(question, 'since') ??
+      extractSingleDate(question, 'after') ??
+      extractSingleDate(question, 'from'),
+    before: between?.before ?? extractSingleDate(question, 'before'),
+    label: extractLabel(question),
+    state: extractState(normalizedQuestion),
+  };
+}
+
+function extractRelativeWindow(normalizedQuestion: string): string | undefined {
+  if (/\btoday\b/.test(normalizedQuestion)) return 'today';
+  if (/\byesterday\b/.test(normalizedQuestion)) return 'yesterday';
+  if (/\b(?:last week|last-week|last_week|last 1 week|in the last week|in the last 1 week|past week|past 1 week|last 7 days|past 7 days)\b/.test(normalizedQuestion)) {
+    return 'last-week';
+  }
+  return undefined;
+}
+
+function extractBetweenRange(question: string): { after?: string; before?: string } | null {
+  const match = question.match(/\bbetween\s+(.+?)\s+and\s+(.+?)(?:[?.!,]|$)/i);
+  if (!match) {
+    return null;
+  }
+
+  const after = normalizeDatePhrase(match[1]);
+  const before = normalizeDatePhrase(match[2]);
+  if (!after && !before) {
+    return null;
+  }
+
+  return { after: after ?? undefined, before: before ?? undefined };
+}
+
+function extractSingleDate(question: string, keyword: 'since' | 'after' | 'before' | 'from'): string | undefined {
+  const regex = new RegExp(
+    `\\b${keyword}\\s+(.+?)(?=\\b(?:and|in the|under the|under|label|state|created|updated|issues?|discussions?)\\b|[?.!,]|$)`,
+    'i',
+  );
+  const match = question.match(regex);
+  if (!match) {
+    return undefined;
+  }
+
+  return normalizeDatePhrase(match[1]) ?? undefined;
+}
+
+function normalizeDatePhrase(raw: string): string | null {
+  const trimmed = raw
+    .trim()
+    .replace(/^on\s+/i, '')
+    .replace(/\s+\b(?:in|under)\s+(?:the\s+)?(.+?)\s+label\b.*$/i, '');
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}(?:[ t]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:z|[+-]\d{2}:\d{2})?)?$/i.test(trimmed)) {
+    return trimmed.replace(' ', 'T');
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString();
+}
+
+function extractLabel(question: string): string | undefined {
+  const match = question.match(/\b(?:in|under)\s+(?:the\s+)?(.+?)\s+label\b/i);
+  if (match?.[1]?.trim()) {
+    return match[1].trim();
+  }
+
+  const statusMatch = question.match(/\bhow\s+is\s+(.+?)\s+looking\b/i);
+  if (isSpecificLabelCandidate(statusMatch?.[1])) {
+    return statusMatch[1].trim();
+  }
+
+  const doingMatch = question.match(/\bhow\s+(?:is|are)\s+(.+?)\s+(?:doing|going|performing)\b/i);
+  if (isSpecificLabelCandidate(doingMatch?.[1])) {
+    return doingMatch[1].trim();
+  }
+
+  return undefined;
+}
+
+function extractState(normalizedQuestion: string): string | undefined {
+  if (/\bopen issues?\b/.test(normalizedQuestion) || /\bstate\s+open\b/.test(normalizedQuestion)) {
+    return 'open';
+  }
+  if (/\bclosed issues?\b/.test(normalizedQuestion) || /\bstate\s+closed\b/.test(normalizedQuestion)) {
+    return 'closed';
+  }
+  if (/\ball issues?\b/.test(normalizedQuestion) || /\bstate\s+all\b/.test(normalizedQuestion)) {
+    return 'all';
+  }
+  return undefined;
+}
+
+function isSpecificLabelCandidate(value?: string): value is string {
+  const trimmed = value?.trim().toLowerCase();
+  if (!trimmed) {
+    return false;
+  }
+  return !['it', 'them', 'this', 'that'].includes(trimmed);
+}

--- a/src/services/issues/run.ts
+++ b/src/services/issues/run.ts
@@ -1,0 +1,53 @@
+import { IssueRun } from '../../contracts/issues.js';
+import { git } from '../git.js';
+import { resolveGitHubToken } from '../discussions/auth.js';
+import { normalizeIssueFilters } from './filters.js';
+import { fetchGitHubIssues } from './fetch.js';
+
+export interface RunIssueFetchOptions {
+  cwd: string;
+  token?: string;
+  when?: string;
+  after?: string;
+  before?: string;
+  state?: string;
+  label?: string;
+  dateField?: 'createdAt' | 'updatedAt';
+  limit?: number;
+}
+
+export async function runIssueFetch(options: RunIssueFetchOptions): Promise<IssueRun> {
+  process.chdir(options.cwd);
+
+  await git.getRepoRoot();
+  const repository = await git.getGitHubRepository();
+  const token = resolveGitHubToken({ explicitToken: options.token });
+  const filters = normalizeIssueFilters({
+    when: options.when,
+    after: options.after,
+    before: options.before,
+    state: options.state,
+    label: options.label,
+    dateField: options.dateField,
+    limit: options.limit,
+  });
+
+  const fetched = await fetchGitHubIssues({
+    repository,
+    token,
+    filters,
+  });
+
+  const run: IssueRun = {
+    version: '1.0',
+    id: new Date().toISOString().replace(/[:.]/g, '-'),
+    timestamp: new Date().toISOString(),
+    repository,
+    filters,
+    pageInfo: fetched.pageInfo,
+    issueCount: fetched.issues.length,
+    issues: fetched.issues,
+  };
+
+  return run;
+}

--- a/tests/smoke/cli.test.ts
+++ b/tests/smoke/cli.test.ts
@@ -96,21 +96,33 @@ describe('CLI Smoke Tests - Installer Flow', () => {
 
       expect(await fileExists(join(copilotRoot, 'agents/forge-discussion-analyzer.agent.md'))).toBe(true);
       expect(await fileExists(join(copilotRoot, 'skills/forge-discussion-analyzer/SKILL.md'))).toBe(true);
+      expect(await fileExists(join(copilotRoot, 'agents/forge-issue-analyzer.agent.md'))).toBe(true);
+      expect(await fileExists(join(copilotRoot, 'skills/forge-issue-analyzer/SKILL.md'))).toBe(true);
 
       expect(await fileExists(join(claudeRoot, 'commands/forge/discussion-analyzer.md'))).toBe(true);
       expect(await fileExists(join(claudeRoot, 'agents/forge-discussion-analyzer.md'))).toBe(true);
       expect(await fileExists(join(claudeRoot, 'forge/workflows/discussion-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(claudeRoot, 'commands/forge/issue-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(claudeRoot, 'agents/forge-issue-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(claudeRoot, 'forge/workflows/issue-analyzer.md'))).toBe(true);
       expect(await fileExists(join(claudeRoot, 'skills/forge:discussion-analyzer/SKILL.md'))).toBe(false);
 
       expect(await fileExists(join(codexRoot, 'skills/forge-discussion-analyzer/SKILL.md'))).toBe(true);
       expect(await fileExists(join(codexRoot, 'agents/forge-discussion-analyzer.md'))).toBe(true);
       expect(await fileExists(join(codexRoot, 'agents/forge-discussion-analyzer.toml'))).toBe(true);
       expect(await fileExists(join(codexRoot, 'forge/workflows/discussion-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(codexRoot, 'skills/forge-issue-analyzer/SKILL.md'))).toBe(true);
+      expect(await fileExists(join(codexRoot, 'agents/forge-issue-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(codexRoot, 'agents/forge-issue-analyzer.toml'))).toBe(true);
+      expect(await fileExists(join(codexRoot, 'forge/workflows/issue-analyzer.md'))).toBe(true);
       expect(await fileExists(join(codexRoot, 'forge:discussion-analyzer.md'))).toBe(false);
 
       expect(await fileExists(join(geminiRoot, 'commands/forge/discussion-analyzer.toml'))).toBe(true);
       expect(await fileExists(join(geminiRoot, 'agents/forge-discussion-analyzer.md'))).toBe(true);
       expect(await fileExists(join(geminiRoot, 'forge/workflows/discussion-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(geminiRoot, 'commands/forge/issue-analyzer.toml'))).toBe(true);
+      expect(await fileExists(join(geminiRoot, 'agents/forge-issue-analyzer.md'))).toBe(true);
+      expect(await fileExists(join(geminiRoot, 'forge/workflows/issue-analyzer.md'))).toBe(true);
       expect(await fileExists(join(geminiRoot, 'forge:discussion-analyzer.md'))).toBe(false);
 
       expect(await fileExists(join(copilotRoot, 'forge/bin/forge.mjs'))).toBe(true);
@@ -134,6 +146,11 @@ describe('CLI Smoke Tests - Installer Flow', () => {
       const codexSkill = await readFile(join(tempHomePath, '.codex/skills/forge-discussion-analyzer/SKILL.md'), 'utf8');
       const codexAgentToml = await readFile(join(tempHomePath, '.codex/agents/forge-discussion-analyzer.toml'), 'utf8');
       const geminiCommand = await readFile(join(tempHomePath, '.gemini/commands/forge/discussion-analyzer.toml'), 'utf8');
+      const issueCopilotAgent = await readFile(join(tempHomePath, '.copilot/agents/forge-issue-analyzer.agent.md'), 'utf8');
+      const issueClaudeCommand = await readFile(join(tempHomePath, '.claude/commands/forge/issue-analyzer.md'), 'utf8');
+      const issueCodexSkill = await readFile(join(tempHomePath, '.codex/skills/forge-issue-analyzer/SKILL.md'), 'utf8');
+      const issueCodexAgentToml = await readFile(join(tempHomePath, '.codex/agents/forge-issue-analyzer.toml'), 'utf8');
+      const issueGeminiCommand = await readFile(join(tempHomePath, '.gemini/commands/forge/issue-analyzer.toml'), 'utf8');
 
       expect(copilotAgent).toContain('node "$HOME/.copilot/forge/bin/forge.mjs" --run forge-discussion-analyzer --question');
       expect(claudeCommand).toContain('---\nname: forge:discussion-analyzer');
@@ -144,6 +161,13 @@ describe('CLI Smoke Tests - Installer Flow', () => {
       expect(codexAgentToml).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "<question>"');
       expect(geminiCommand).toContain('Forge backend: node \\"$HOME/.gemini/forge/bin/forge.mjs\\" --run forge-discussion-analyzer --question \\"<question>\\"');
       expect(geminiCommand).toContain('Do not inspect the codebase, search the repository, or read files under ~/.gemini before deciding what to do.');
+      expect(issueCopilotAgent).toContain('node "$HOME/.copilot/forge/bin/forge.mjs" --run forge-issue-analyzer --question');
+      expect(issueClaudeCommand).toContain('---\nname: forge:issue-analyzer');
+      expect(issueClaudeCommand).toContain(`@${join(tempHomePath, '.claude/forge/workflows/issue-analyzer.md')}`);
+      expect(issueCodexSkill).toContain('`$forge-issue-analyzer`');
+      expect(issueCodexSkill).toContain(`@${join(tempHomePath, '.codex/forge/workflows/issue-analyzer.md')}`);
+      expect(issueCodexAgentToml).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-issue-analyzer --question "<question>"');
+      expect(issueGeminiCommand).toContain('Forge backend: node \\"$HOME/.gemini/forge/bin/forge.mjs\\" --run forge-issue-analyzer --question \\"<question>\\"');
     });
 
     it('preserves user customizations for managed markdown assets on reinstall', async () => {
@@ -388,9 +412,13 @@ describe('CLI Smoke Tests - Installer Flow', () => {
 
         expect(installRun.exitCode).toBe(0);
         expect(await fileExists(join(packedHomePath, '.copilot/agents/forge-discussion-analyzer.agent.md'))).toBe(true);
+        expect(await fileExists(join(packedHomePath, '.copilot/agents/forge-issue-analyzer.agent.md'))).toBe(true);
         expect(await fileExists(join(packedHomePath, '.claude/commands/forge/discussion-analyzer.md'))).toBe(true);
+        expect(await fileExists(join(packedHomePath, '.claude/commands/forge/issue-analyzer.md'))).toBe(true);
         expect(await fileExists(join(packedHomePath, '.codex/skills/forge-discussion-analyzer/SKILL.md'))).toBe(true);
+        expect(await fileExists(join(packedHomePath, '.codex/skills/forge-issue-analyzer/SKILL.md'))).toBe(true);
         expect(await fileExists(join(packedHomePath, '.gemini/commands/forge/discussion-analyzer.toml'))).toBe(true);
+        expect(await fileExists(join(packedHomePath, '.gemini/commands/forge/issue-analyzer.toml'))).toBe(true);
         expect(await fileExists(join(installPath, '.codex'))).toBe(false);
         expect(await fileExists(join(installPath, '.gemini'))).toBe(false);
       } finally {

--- a/tests/unit/services/assistant-exposure.test.ts
+++ b/tests/unit/services/assistant-exposure.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { forgeDiscussionAnalyzerEntry } from '../../../src/services/assistants/summonables.js';
+import { forgeDiscussionAnalyzerEntry, forgeIssueAnalyzerEntry } from '../../../src/services/assistants/summonables.js';
 import { getExposedSummonableName, getSummonableRoute, toNamespacedSummonableName } from '../../../src/services/assistants/exposure.js';
 
 describe('assistant exposure naming', () => {
   it('keeps the runtime id stable while command runtimes use the namespaced command alias', () => {
     expect(forgeDiscussionAnalyzerEntry.id).toBe('forge-discussion-analyzer');
+    expect(forgeIssueAnalyzerEntry.id).toBe('forge-issue-analyzer');
     expect(getExposedSummonableName('claude', 'command', forgeDiscussionAnalyzerEntry)).toBe('forge:discussion-analyzer');
     expect(getExposedSummonableName('gemini', 'command', forgeDiscussionAnalyzerEntry)).toBe('forge:discussion-analyzer');
+    expect(getExposedSummonableName('claude', 'command', forgeIssueAnalyzerEntry)).toBe('forge:issue-analyzer');
+    expect(getExposedSummonableName('gemini', 'command', forgeIssueAnalyzerEntry)).toBe('forge:issue-analyzer');
   });
 
   it('keeps agent and skill ids stable for Copilot, Codex, and Claude agents', () => {
@@ -14,15 +17,25 @@ describe('assistant exposure naming', () => {
     expect(getExposedSummonableName('copilot', 'skill', forgeDiscussionAnalyzerEntry)).toBe('forge-discussion-analyzer');
     expect(getExposedSummonableName('codex', 'skill', forgeDiscussionAnalyzerEntry)).toBe('forge-discussion-analyzer');
     expect(getExposedSummonableName('claude', 'agent', forgeDiscussionAnalyzerEntry)).toBe('forge-discussion-analyzer');
+    expect(getExposedSummonableName('copilot', 'agent', forgeIssueAnalyzerEntry)).toBe('forge-issue-analyzer');
+    expect(getExposedSummonableName('copilot', 'skill', forgeIssueAnalyzerEntry)).toBe('forge-issue-analyzer');
+    expect(getExposedSummonableName('codex', 'skill', forgeIssueAnalyzerEntry)).toBe('forge-issue-analyzer');
+    expect(getExposedSummonableName('claude', 'agent', forgeIssueAnalyzerEntry)).toBe('forge-issue-analyzer');
   });
 
   it('derives the command path route and converts only the leading namespace separator', () => {
     expect(toNamespacedSummonableName('forge-discussion-analyzer')).toBe('forge:discussion-analyzer');
+    expect(toNamespacedSummonableName('forge-issue-analyzer')).toBe('forge:issue-analyzer');
     expect(toNamespacedSummonableName('singleword')).toBe('singleword');
     expect(getSummonableRoute('forge-discussion-analyzer')).toEqual({
       namespace: 'forge',
       localName: 'discussion-analyzer',
       namespacedName: 'forge:discussion-analyzer',
+    });
+    expect(getSummonableRoute('forge-issue-analyzer')).toEqual({
+      namespace: 'forge',
+      localName: 'issue-analyzer',
+      namespacedName: 'forge:issue-analyzer',
     });
   });
 });

--- a/tests/unit/services/claude-assistants.test.ts
+++ b/tests/unit/services/claude-assistants.test.ts
@@ -26,6 +26,9 @@ describe('Claude assistant translation', () => {
     const commandPath = join(tempHomePath, '.claude/commands/forge/discussion-analyzer.md');
     const agentPath = join(tempHomePath, '.claude/agents/forge-discussion-analyzer.md');
     const workflowPath = join(tempHomePath, '.claude/forge/workflows/discussion-analyzer.md');
+    const issueCommandPath = join(tempHomePath, '.claude/commands/forge/issue-analyzer.md');
+    const issueAgentPath = join(tempHomePath, '.claude/agents/forge-issue-analyzer.md');
+    const issueWorkflowPath = join(tempHomePath, '.claude/forge/workflows/issue-analyzer.md');
     const runtimeEntryPath = join(tempHomePath, '.claude/forge/bin/forge.mjs');
 
     expect(result.status).toBe('success');
@@ -33,6 +36,9 @@ describe('Claude assistant translation', () => {
     const command = await readFile(commandPath, 'utf8');
     const agent = await readFile(agentPath, 'utf8');
     const workflow = await readFile(workflowPath, 'utf8');
+    const issueCommand = await readFile(issueCommandPath, 'utf8');
+    const issueAgent = await readFile(issueAgentPath, 'utf8');
+    const issueWorkflow = await readFile(issueWorkflowPath, 'utf8');
 
     expect(command).toContain('---\nname: forge:discussion-analyzer');
     expect(command).toContain('argument-hint: "<question>"');
@@ -47,6 +53,14 @@ describe('Claude assistant translation', () => {
 
     expect(workflow).toContain('node "$HOME/.claude/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "$ARGUMENTS"');
     expect(workflow).toContain('Every query must use Forge live fetches');
+
+    expect(issueCommand).toContain('---\nname: forge:issue-analyzer');
+    expect(issueCommand).toContain(`@${issueWorkflowPath}`);
+    expect(issueAgent).toContain('---\nname: forge-issue-analyzer');
+    expect(issueAgent).toContain('You are the Forge Issue Analyzer.');
+    expect(issueAgent).toContain('node "$HOME/.claude/forge/bin/forge.mjs" --run forge-issue-analyzer --question "<question>"');
+    expect(issueWorkflow).toContain('node "$HOME/.claude/forge/bin/forge.mjs" --run forge-issue-analyzer --question "$ARGUMENTS"');
+
     await expect(access(runtimeEntryPath)).resolves.toBeUndefined();
     await expect(access(join(tempHomePath, '.claude/skills/forge:discussion-analyzer/SKILL.md'))).rejects.toThrow();
   });

--- a/tests/unit/services/codex-gemini-assistants.test.ts
+++ b/tests/unit/services/codex-gemini-assistants.test.ts
@@ -27,6 +27,10 @@ describe('Codex assistant translation', () => {
     const agentPath = join(tempHomePath, '.codex/agents/forge-discussion-analyzer.md');
     const agentTomlPath = join(tempHomePath, '.codex/agents/forge-discussion-analyzer.toml');
     const workflowPath = join(tempHomePath, '.codex/forge/workflows/discussion-analyzer.md');
+    const issueSkillPath = join(tempHomePath, '.codex/skills/forge-issue-analyzer/SKILL.md');
+    const issueAgentPath = join(tempHomePath, '.codex/agents/forge-issue-analyzer.md');
+    const issueAgentTomlPath = join(tempHomePath, '.codex/agents/forge-issue-analyzer.toml');
+    const issueWorkflowPath = join(tempHomePath, '.codex/forge/workflows/issue-analyzer.md');
 
     expect(result.status).toBe('success');
     expect(await readFile(skillPath, 'utf8')).toContain('`$forge-discussion-analyzer`');
@@ -36,6 +40,12 @@ describe('Codex assistant translation', () => {
     expect(await readFile(agentTomlPath, 'utf8')).toContain('sandbox_mode = "workspace-write"');
     expect(await readFile(agentTomlPath, 'utf8')).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "<question>"');
     expect(await readFile(workflowPath, 'utf8')).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "$ARGUMENTS"');
+
+    expect(await readFile(issueSkillPath, 'utf8')).toContain('`$forge-issue-analyzer`');
+    expect(await readFile(issueSkillPath, 'utf8')).toContain(`@${issueWorkflowPath}`);
+    expect(await readFile(issueAgentPath, 'utf8')).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-issue-analyzer --question "<question>"');
+    expect(await readFile(issueAgentTomlPath, 'utf8')).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-issue-analyzer --question "<question>"');
+    expect(await readFile(issueWorkflowPath, 'utf8')).toContain('node "$HOME/.codex/forge/bin/forge.mjs" --run forge-issue-analyzer --question "$ARGUMENTS"');
   });
 
   it('preserves Codex skill customizations on reinstall', async () => {
@@ -193,7 +203,11 @@ describe('Gemini assistant translation', () => {
     const commandPath = join(tempHomePath, '.gemini/commands/forge/discussion-analyzer.toml');
     const agentPath = join(tempHomePath, '.gemini/agents/forge-discussion-analyzer.md');
     const workflowPath = join(tempHomePath, '.gemini/forge/workflows/discussion-analyzer.md');
+    const issueCommandPath = join(tempHomePath, '.gemini/commands/forge/issue-analyzer.toml');
+    const issueAgentPath = join(tempHomePath, '.gemini/agents/forge-issue-analyzer.md');
+    const issueWorkflowPath = join(tempHomePath, '.gemini/forge/workflows/issue-analyzer.md');
     const command = await readFile(commandPath, 'utf8');
+    const issueCommand = await readFile(issueCommandPath, 'utf8');
 
     expect(result.status).toBe('success');
     expect(command).toContain('Forge backend: node \\"$HOME/.gemini/forge/bin/forge.mjs\\" --run forge-discussion-analyzer --question \\"<question>\\"');
@@ -201,6 +215,10 @@ describe('Gemini assistant translation', () => {
     expect(await readFile(agentPath, 'utf8')).toContain('tools:\n  - read_file\n  - run_shell_command');
     expect(await readFile(agentPath, 'utf8')).toContain('node "$HOME/.gemini/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "<question>"');
     expect(await readFile(workflowPath, 'utf8')).toContain('node "$HOME/.gemini/forge/bin/forge.mjs" --run forge-discussion-analyzer --question "$ARGUMENTS"');
+
+    expect(issueCommand).toContain('Forge backend: node \\"$HOME/.gemini/forge/bin/forge.mjs\\" --run forge-issue-analyzer --question \\"<question>\\"');
+    expect(await readFile(issueAgentPath, 'utf8')).toContain('node "$HOME/.gemini/forge/bin/forge.mjs" --run forge-issue-analyzer --question "<question>"');
+    expect(await readFile(issueWorkflowPath, 'utf8')).toContain('node "$HOME/.gemini/forge/bin/forge.mjs" --run forge-issue-analyzer --question "$ARGUMENTS"');
   });
 
   it('preserves Gemini agent customizations on reinstall', async () => {

--- a/tests/unit/services/discussions.test.ts
+++ b/tests/unit/services/discussions.test.ts
@@ -759,6 +759,9 @@ describe('Discussions services', () => {
   });
 
   it('does not keyword-trim an explicitly scoped category health result set', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-03T12:00:00.000Z'));
+
     const run = {
       version: '1.0' as const,
       id: '2026-03-03T13-00-00-000Z',
@@ -840,6 +843,7 @@ describe('Discussions services', () => {
       expect(answer).toContain('Provisioning stuck');
     } finally {
       fetchSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/tests/unit/services/issues.test.ts
+++ b/tests/unit/services/issues.test.ts
@@ -1,0 +1,213 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runIssueAnalyzer } from '../../../src/services/issues/analyze.js';
+import { analyzeIssueRequestIntent } from '../../../src/services/issues/request-intent.js';
+import { fetchGitHubIssues } from '../../../src/services/issues/fetch.js';
+import { normalizeIssueFilters } from '../../../src/services/issues/filters.js';
+import * as issueRunService from '../../../src/services/issues/run.js';
+
+describe('Issue services', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'forge-issues-'));
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function mockAnalyzerFetch<T extends { id: string }>(run: T) {
+    return vi.spyOn(issueRunService, 'runIssueFetch').mockResolvedValue(run as never);
+  }
+
+  it('normalizes relative issue filters and defaults state to all', () => {
+    const now = new Date('2026-03-03T12:00:00.000Z');
+    const filters = normalizeIssueFilters({ when: 'yesterday', limit: 5, now });
+
+    expect(filters.when).toBe('yesterday');
+    expect(filters.after).toBeDefined();
+    expect(filters.before).toBeDefined();
+    expect(filters.dateField).toBe('createdAt');
+    expect(filters.state).toBe('all');
+    expect(filters.limit).toBe(5);
+  });
+
+  it('fetches issues from GitHub and filters out pull requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ([
+        {
+          id: 1,
+          number: 11,
+          title: 'Issue one',
+          html_url: 'https://github.com/ajitgunturi/forge/issues/11',
+          created_at: '2026-03-03T08:00:00.000Z',
+          updated_at: '2026-03-03T09:00:00.000Z',
+          closed_at: null,
+          state: 'open',
+          user: { login: 'ajitg' },
+          labels: [{ name: 'bug' }],
+          body: 'An open bug.',
+          comments: 2,
+        },
+        {
+          id: 2,
+          number: 12,
+          title: 'PR one',
+          html_url: 'https://github.com/ajitgunturi/forge/pull/12',
+          created_at: '2026-03-03T08:00:00.000Z',
+          updated_at: '2026-03-03T09:00:00.000Z',
+          closed_at: null,
+          state: 'open',
+          user: { login: 'ajitg' },
+          labels: [{ name: 'bug' }],
+          body: 'Actually a pull request.',
+          comments: 0,
+          pull_request: {},
+        },
+      ]),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchGitHubIssues({
+      repository: {
+        owner: 'ajitgunturi',
+        name: 'forge',
+        remoteUrl: 'https://github.com/ajitgunturi/forge.git',
+      },
+      token: 'token',
+      filters: normalizeIssueFilters({
+        when: 'today',
+        label: 'bug',
+        state: 'open',
+        limit: 10,
+        now: new Date('2026-03-03T12:00:00.000Z'),
+      }),
+    });
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.title).toBe('Issue one');
+    expect(result.issues[0]?.labels).toContain('bug');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs forge-issue-analyzer from live fetched issues and saves a summary artifact', async () => {
+    const run = {
+      version: '1.0' as const,
+      id: '2026-03-03T10-00-00-000Z',
+      timestamp: '2026-03-03T10:00:00.000Z',
+      repository: {
+        owner: 'ajitgunturi',
+        name: 'forge',
+        remoteUrl: 'https://github.com/ajitgunturi/forge.git',
+      },
+      filters: normalizeIssueFilters({ when: 'today', state: 'all', limit: 10 }),
+      pageInfo: {
+        hasNextPage: false,
+        nextPage: undefined,
+        fetchedPages: 1,
+      },
+      issueCount: 2,
+      issues: [
+        {
+          id: 'I_1',
+          number: 201,
+          title: 'Bug: install hangs',
+          url: 'https://github.com/ajitgunturi/forge/issues/201',
+          createdAt: '2026-03-03T08:00:00.000Z',
+          updatedAt: '2026-03-03T09:00:00.000Z',
+          closedAt: null,
+          state: 'open' as const,
+          author: 'ajitg',
+          labels: ['bug'],
+          bodyText: 'Install fails with token setup.',
+          commentsCount: 2,
+        },
+        {
+          id: 'I_2',
+          number: 202,
+          title: 'Chore: docs cleanup',
+          url: 'https://github.com/ajitgunturi/forge/issues/202',
+          createdAt: '2026-03-03T07:00:00.000Z',
+          updatedAt: '2026-03-03T09:30:00.000Z',
+          closedAt: '2026-03-03T10:00:00.000Z',
+          state: 'closed' as const,
+          author: 'ajitg',
+          labels: ['documentation'],
+          bodyText: 'Close docs cleanup.',
+          commentsCount: 1,
+        },
+      ],
+    };
+
+    const fetchSpy = mockAnalyzerFetch(run);
+
+    try {
+      const answer = await runIssueAnalyzer({
+        cwd: tempDir,
+        question: 'summarize all issues',
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(answer).toContain('GitHub Issues Digest');
+      expect(answer).toContain('State Summary');
+      expect(answer).toContain('Bug: install hangs');
+
+      const latestSummaryRaw = await readFile(
+        join(tempDir, '.forge/issues/summary/latest.json'),
+        'utf8',
+      );
+      const latestSummary = JSON.parse(latestSummaryRaw) as {
+        question: string;
+        answer: string;
+        sourceRunId: string;
+        source: string;
+        issueCount: number;
+      };
+
+      expect(latestSummary.question).toBe('summarize all issues');
+      expect(latestSummary.answer).toContain('GitHub Issues Digest');
+      expect(latestSummary.sourceRunId).toBe('2026-03-03T10-00-00-000Z');
+      expect(latestSummary.source).toBe('live-fetch');
+      expect(latestSummary.issueCount).toBe(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('fails fast when the question asks for discussions instead of issues', async () => {
+    await expect(
+      runIssueAnalyzer({
+        cwd: tempDir,
+        question: 'show me discussions updated in the last week',
+      }),
+    ).rejects.toThrow(/Forge analyzes GitHub Issues only/);
+
+    await expect(
+      runIssueAnalyzer({
+        cwd: tempDir,
+        question: 'show me discussions updated in the last week',
+      }),
+    ).rejects.toThrow(/Want "show me issues updated in the last week" instead/);
+  });
+
+  it('parses issue intent filters from question text', () => {
+    const intent = analyzeIssueRequestIntent({
+      question: 'count open issues created between 2026-01-01 and 2026-01-31 in the bug label',
+      limit: 25,
+    });
+
+    expect(intent.parsedFilters.after).toBe('2026-01-01T00:00:00.000Z');
+    expect(intent.parsedFilters.before).toBe('2026-01-31T23:59:59.999Z');
+    expect(intent.parsedFilters.label).toBe('bug');
+    expect(intent.parsedFilters.state).toBe('open');
+    expect(intent.parsedFilters.dateField).toBe('createdAt');
+    expect(intent.refreshMode).toBe('fetch');
+  });
+});


### PR DESCRIPTION
## Summary
- document new issue analyzer skill usage, installer help output, and agent rules in AGENTS.md
- expand docs for adding skills, releasing, and runtime installers plus expose issue-analyzer contracts/errors/workflows
- add issue analyzer services (fetch/prepare/analyze/filters/run) with tests covering the new assistant behavior

## Testing
- Not run (not requested)