### PR TITLE
chore: update stale ajitgunturi/* org refs to arcanelabsio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Forge
 
 [![npm version](https://img.shields.io/npm/v/forge-ai-assist)](https://www.npmjs.com/package/forge-ai-assist)
-[![CI](https://github.com/ajitgunturi/forge/actions/workflows/ci.yml/badge.svg)](https://github.com/ajitgunturi/forge/actions/workflows/ci.yml)
+[![CI](https://github.com/arcanelabsio/forge/actions/workflows/ci.yml/badge.svg)](https://github.com/arcanelabsio/forge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "cli",
     "forge"
   ],
-  "homepage": "https://github.com/ajitgunturi/forge#readme",
+  "homepage": "https://github.com/arcanelabsio/forge#readme",
   "bugs": {
-    "url": "https://github.com/ajitgunturi/forge/issues"
+    "url": "https://github.com/arcanelabsio/forge/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ajitgunturi/forge.git"
+    "url": "git+https://github.com/arcanelabsio/forge.git"
   },
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ try {
     if (error instanceof Error) {
       console.error(error.message);
     }
-    console.error("\nIf this looks like a bug, please report it at:\nhttps://github.com/ajitgunturi/forge/issues");
+    console.error("\nIf this looks like a bug, please report it at:\nhttps://github.com/arcanelabsio/forge/issues");
     process.exitCode = 1;
   }
 }

--- a/tests/smoke/cli.test.ts
+++ b/tests/smoke/cli.test.ts
@@ -422,7 +422,7 @@ describe('CLI Smoke Tests - Installer Lifecycle', () => {
 
       expect(manifest.name).toBe('forge-ai-assist');
       expect(manifest.bin).toEqual({ forge: './dist/cli.js' });
-      expect(manifest.repository?.url).toContain('github.com/ajitgunturi/forge.git');
+      expect(manifest.repository?.url).toContain('github.com/arcanelabsio/forge.git');
       expect(manifest.publishConfig?.access).toBe('public');
     });
 


### PR DESCRIPTION
Updates pre-org-rename URLs across:
- `package.json` — homepage, bugs.url, repository.url
- `src/cli.ts` — runtime error message linking to issue tracker
- `README.md` — CI badge URL
- `tests/smoke/cli.test.ts` — test assertion asserting package.json URL

Test assertion updated alongside package.json to keep CI green.

Identified in the 2026-04-17 org audit sweep.